### PR TITLE
Add #3 검색 페이지 추가

### DIFF
--- a/src/main/java/Recorders/ggogit/controller/home/TreeController.java
+++ b/src/main/java/Recorders/ggogit/controller/home/TreeController.java
@@ -42,9 +42,15 @@ public class TreeController {
         // 테스트 위한 트리 리스트(나중에 리포지로 빠짐)
         List<Tree> trees = new ArrayList<>();
         long id = 1L;
-        for (int i = 0; i < 8; i++) {
+        for (int i = 0; i < 5; i++) {
             Tree t1 = Tree.createTestTree();
             t1.setId(id++);
+            trees.add(t1);
+        }
+        for (int i = 0; i < 3; i++) {
+            Tree t1 = Tree.createTestTree();
+            t1.setId(id++);
+            t1.setBookName("testBook2");
             trees.add(t1);
         }
 

--- a/src/main/java/Recorders/ggogit/controller/home/TreeController.java
+++ b/src/main/java/Recorders/ggogit/controller/home/TreeController.java
@@ -2,7 +2,9 @@ package Recorders.ggogit.controller.home;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Controller("homeTreeController")
 @RequestMapping("/home/tree")
@@ -12,4 +14,11 @@ public class TreeController {
     public String treeSearch() {
         return "view/home/tree/search/index";
     }
+
+    @PostMapping("/search")
+    public String postMethodName(@RequestParam("treeSearchText") String treeSearchText) {
+        System.out.println(treeSearchText);
+        return "redirect:/home/tree/search";
+    }
+
 }

--- a/src/main/java/Recorders/ggogit/controller/home/TreeController.java
+++ b/src/main/java/Recorders/ggogit/controller/home/TreeController.java
@@ -1,10 +1,20 @@
 package Recorders.ggogit.controller.home;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import Recorders.ggogit.entity.Tree;
 
 @Controller("homeTreeController")
 @RequestMapping("/home/tree")
@@ -16,9 +26,47 @@ public class TreeController {
     }
 
     @PostMapping("/search")
-    public String postMethodName(@RequestParam("treeSearchText") String treeSearchText) {
+    public String treeSearch(@RequestParam("treeSearchText") String treeSearchText,
+            RedirectAttributes redirectAttributes) {
         System.out.println(treeSearchText);
-        return "redirect:/home/tree/search";
+        redirectAttributes.addAttribute("treeSearchText", treeSearchText);
+        return "redirect:/home/tree/search/result/{treeSearchText}";
+    }
+
+    @GetMapping("/search/result/{treeSearchText}")
+    public String treeSearchResult(@PathVariable String treeSearchText,
+            Model model) {
+        // 더미 데이터
+        // 검색 결과 담는 map
+        Map<Long, Tree> map = new HashMap<>();
+        // 테스트 위한 트리 리스트(나중에 리포지로 빠짐)
+        List<Tree> trees = new ArrayList<>();
+        long id = 1L;
+        for (int i = 0; i < 8; i++) {
+            Tree t1 = Tree.createTestTree();
+            t1.setId(id++);
+            trees.add(t1);
+        }
+
+        // 트리 찾는 과정(나중에 서비스로 빠짐)
+        for (Tree t : trees) {
+            if (t.getBookName().equals(treeSearchText)) {
+                map.put(t.getId(), t);
+                System.out.println(t.getId());
+            }
+        }
+
+        model.addAttribute("resultMap", map);
+
+        return "view/home/tree/search/tree-list";
+    }
+
+    @PostMapping("/search/result/{treeSearchText}")
+    public String treeSearchResult(@RequestParam("treeSearchText") String treeSearchText,
+            RedirectAttributes redirectAttributes) {
+        System.out.println(treeSearchText);
+        redirectAttributes.addAttribute("treeSearchText", treeSearchText);
+        return "redirect:/home/tree/search/result/{treeSearchText}";
     }
 
 }

--- a/src/main/java/Recorders/ggogit/entity/Tree.java
+++ b/src/main/java/Recorders/ggogit/entity/Tree.java
@@ -3,6 +3,7 @@ package Recorders.ggogit.entity;
 import lombok.*;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 
 @Getter
 @Setter
@@ -24,6 +25,7 @@ public class Tree {
     private Boolean visibility;
     private Timestamp createdAt;
     private Timestamp updatedAt;
+    private Boolean complete;
 
     public void setSeedCategoryType(String seedCategory) {
         this.seedCategoryType = SeedCategoryType.of(seedCategory);
@@ -31,5 +33,26 @@ public class Tree {
 
     public void setBookCategoryType(String bookCategory) {
         this.bookCategoryType = BookCategoryType.of(bookCategory);
+    }
+
+    public static Tree createTestTree() {
+        Tree testTree = new Tree();
+        testTree.setId(1L);
+        testTree.setSeedCategoryType("book");
+        testTree.setImgUrl("card-felt__cover.svg");
+        testTree.setBookName("testBook");
+        testTree.setAuthor("testAuthor");
+        testTree.setPublisher("testPub");
+        testTree.setTotalPage(100);
+        testTree.setBookCategoryType("nonFiction");
+        testTree.setTreeName("testTreeName");
+        testTree.setDescription("testDes");
+        testTree.setVisibility(true);
+        testTree.setCreatedAt(Timestamp.valueOf(LocalDateTime.now()));
+        testTree.setUpdatedAt(Timestamp.valueOf(LocalDateTime.now()));
+        testTree.setComplete(true);
+
+        return testTree;
+
     }
 }

--- a/src/main/java/Recorders/ggogit/entity/TreeSearchText.java
+++ b/src/main/java/Recorders/ggogit/entity/TreeSearchText.java
@@ -1,0 +1,2 @@
+package Recorders.ggogit.entity;public class TreeSearchText {
+}

--- a/src/main/java/Recorders/ggogit/entity/TreeSearchText.java
+++ b/src/main/java/Recorders/ggogit/entity/TreeSearchText.java
@@ -1,2 +1,0 @@
-package Recorders.ggogit.entity;public class TreeSearchText {
-}

--- a/src/main/resources/static/css/fragments.css
+++ b/src/main/resources/static/css/fragments.css
@@ -72,49 +72,49 @@
      FILE: background.html
 /   ========================================== */
 
-.text-book-info{
-    display: flex;
-    flex-direction: column;
-    justify-content: flex-start;
-    width: 100%;
-    height: 137px;
+.text-book-info {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  width: 100%;
+  height: 137px;
 }
-.text-book-info-frame{
+.text-book-info-frame {
   width: 100%;
   display: flex;
   background: var(--white);
 }
-.text-book-info__seed{
-    display: inline;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-size: 10px;
-    font-weight: var(--medium);
-    line-height: var(--line-height-main);
-    letter-spacing: var(--letter-spacing-main);
-    color: var(--white);
-    background: var(--main1);
+.text-book-info__seed {
+  display: inline;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: var(--medium);
+  line-height: var(--line-height-main);
+  letter-spacing: var(--letter-spacing-main);
+  color: var(--white);
+  background: var(--main1);
 }
-.text-book-info__title{
-    font-size: 24px;
-    font-weight: var(--bold);
-    line-height: var(--line-height-main);
-    letter-spacing: var(--letter-spacing-main);
-    color: var(--main1);
+.text-book-info__title {
+  font-size: 24px;
+  font-weight: var(--bold);
+  line-height: var(--line-height-main);
+  letter-spacing: var(--letter-spacing-main);
+  color: var(--main1);
 }
-.text-book-info__create{
-    width: 100%;
-    display: flex;
-    justify-content: left;
-    gap: 2px;
+.text-book-info__create {
+  width: 100%;
+  display: flex;
+  justify-content: left;
+  gap: 2px;
 }
-.text-book-info-create-info{
-    display: flex;
-    font-size: 14px;
-    font-weight: var(--regular);
-    line-height: var(--line-height-main);
-    letter-spacing: var(--letter-spacing-main);
-    color: var(--text-sub);
+.text-book-info-create-info {
+  display: flex;
+  font-size: 14px;
+  font-weight: var(--regular);
+  line-height: var(--line-height-main);
+  letter-spacing: var(--letter-spacing-main);
+  color: var(--text-sub);
 }
 /*  ========================================== /
      FRAGMENT: FUll 가로 버튼 - link 버전
@@ -720,6 +720,7 @@ button {
 .search__form {
   display: flex;
   align-items: center;
+  gap: 18px;
 }
 .search-bar {
   background: var(--main2);
@@ -803,8 +804,8 @@ button {
   display: flex;
   align-items: center;
   justify-content: center;
-}/*card- 기본정보 */
-.card-tree-info{
+} /*card- 기본정보 */
+.card-tree-info {
   height: 41px;
   border-bottom: 1px solid var(--main1);
   font-size: 20px;
@@ -813,25 +814,24 @@ button {
   line-height: var(--line-height-main);
   letter-spacing: var(--letter-spacing-main);
 }
-.card-tree-info__frame{
+.card-tree-info__frame {
   width: 245px;
   height: 75px;
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
-.card-tree-info__title{
+.card-tree-info__title {
   font-size: 14px;
   color: var(--main1, #323a27);
   font-weight: var(--medium);
   line-height: var(--line-height-main);
   letter-spacing: var(--letter-spacing-main);
 }
-.card-tree-info__content{
+.card-tree-info__content {
   font-size: 14px;
   color: var(--text-sub, #767676);
   font-weight: var(--regular);
   line-height: var(--line-height-main);
   letter-spacing: var(--letter-spacing-main);
-
 }

--- a/src/main/resources/static/css/fragments.css
+++ b/src/main/resources/static/css/fragments.css
@@ -161,8 +161,11 @@
     FRAGMENT: 네비게이션바
 /   ========================================== */
 .nav-box {
+  width: 100%;
   box-shadow: 0 -5px 10px -5px rgba(0, 0, 0, 0.3);
   background-color: var(--white, #ffffff);
+  position: fixed;
+  bottom: 0px;
 }
 
 .nav-box__list {
@@ -834,4 +837,106 @@ button {
   font-weight: var(--regular);
   line-height: var(--line-height-main);
   letter-spacing: var(--letter-spacing-main);
+}
+/* =============================
+        나뭇잎 전체 검색
+         search-filter-log 
+    ============================== */
+
+.search-filter {
+  display: flex;
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+.search-filter-log__checkbox-input {
+  display: none;
+}
+
+.search-filter-log__checkbox-input-text {
+  display: block;
+  width: fit-content;
+  font-size: 12px;
+  font-weight: var(--medium, 500);
+  color: var(--text-sub, #767676);
+  border-radius: 8px;
+  background-color: var(--btn-no-active);
+  padding: 12px 20px;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.search-filter-log__checkbox-input:checked
+  + .search-filter-log__checkbox-input-text {
+  background-color: var(--main1, #323a27);
+  color: var(--white, #ffffff);
+}
+/* ================ */
+/* tree card */
+/* ================ */
+.card-tree-details {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.card-tree-detail {
+  display: flex;
+  flex-direction: row;
+  margin-bottom: 40px;
+}
+
+.card-tree__book-cover {
+  width: 80px;
+  height: 120px;
+  margin-right: 8px;
+}
+
+.card-tree-detail__box {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  line-height: var(--line-height-main);
+  letter-spacing: var(--letter-spacing-main);
+  transform: translateY(-8px);
+}
+
+.card-tree-detail__tags {
+  line-height: var(--line-height-sub);
+}
+
+.card-tree-detail__tag {
+  color: var(--text-sub);
+  font-size: 10px;
+  margin-right: 2px;
+}
+
+.card-tree-detail__name {
+  font-size: 18px;
+  font-weight: var(--bold);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.card-tree-detail__explanation {
+  font-size: 14px;
+  font-weight: var(--regular);
+  color: var(--text-sub);
+}
+
+.card-tree-detail__info {
+  font-size: 14px;
+  font-weight: var(--regular);
+  color: var(--text-sub);
+}
+
+.card-tree-detail__info-created-date {
+  font-size: 14px;
+  font-weight: var(--regular);
+  color: var(--text-sub);
+  display: flex;
+  justify-content: end;
+  transform: translateY(8px);
 }

--- a/src/main/resources/static/css/fragments.css
+++ b/src/main/resources/static/css/fragments.css
@@ -27,14 +27,13 @@
   position: relative;
 }
 .header-search-link__placeholder {
-  color: #767676;
-  text-align: center;
-  font-family: "Pretendard-SemiBold", sans-serif;
+  color: var(--text-sub);
   font-size: 14px;
-  line-height: 140%;
-  letter-spacing: -0.0025em;
-  font-weight: 600;
+  line-height: var(--line-height-main);
+  letter-spacing: var(--letter-spacing-main);
+  font-weight: var(--medium);
   position: relative;
+  transform: translateY(8%);
 }
 .header-search-link__icon {
   flex-shrink: 0;
@@ -164,8 +163,6 @@
   width: 100%;
   box-shadow: 0 -5px 10px -5px rgba(0, 0, 0, 0.3);
   background-color: var(--white, #ffffff);
-  position: fixed;
-  bottom: 0px;
 }
 
 .nav-box__list {

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -52,6 +52,13 @@
   flex-shrink: 0;
   position: absolute;
 }
+/*아래는 트리 생성 버튼이 nav에 가려지는거 방지용 */
+.btn-full-width-link-container::after {
+  content: " ";
+  display: block;
+  width: 100%;
+  height: 100px;
+}
 
 .book-tree-input-form-container {
   display: flex;

--- a/src/main/resources/static/css/layout.css
+++ b/src/main/resources/static/css/layout.css
@@ -1,101 +1,101 @@
 .header-search-container {
-    padding: 30px 24px 40px 24px;
+  padding: 30px 24px 40px 24px;
 }
 
 .my-tree-container {
-    display: flex;
-    flex-direction: column;
-    gap: 0;
-    align-items: flex-start;
-    justify-content: flex-start;
-    align-self: stretch;
-    flex-shrink: 0;
-    position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  align-items: flex-start;
+  justify-content: flex-start;
+  align-self: stretch;
+  flex-shrink: 0;
+  position: relative;
 }
 
 .my-tree-title-container {
-    padding: 0 24px 200px 24px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    align-self: stretch;
-    flex-shrink: 0;
-    position: relative;
+  padding: 0 24px 200px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  align-self: stretch;
+  flex-shrink: 0;
+  position: relative;
 }
 
 .text-info-container {
-    display: flex;
-    flex-direction: row;
-    align-self: stretch;
-    margin: 70px 0 300px 0;
-    align-items: self-start;
-    justify-content: center;
-    flex-shrink: 0;
-    position: relative;
+  display: flex;
+  flex-direction: row;
+  align-self: stretch;
+  margin: 70px 0 300px 0;
+  align-items: self-start;
+  justify-content: center;
+  flex-shrink: 0;
+  position: relative;
 }
 
 .book-img-container {
-    z-index: 10;
-    margin: 0 auto;
-    top: 80px;
-    left: 50%;
-    transform: translateX(-50%);
-    position: absolute;
+  z-index: 10;
+  margin: 0 auto;
+  top: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  position: absolute;
 }
 
 .btn-full-width-link-container {
-    margin: 0 5% 28px 5%;
-    width: 90%;
-    top: 550px;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    position: absolute;
+  margin: 0 5% 28px 5%;
+  width: 90%;
+  top: 550px;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  position: absolute;
 }
 
 .book-tree-input-form-container {
-    display: flex;
-    flex-direction: column;
+  display: flex;
+  flex-direction: column;
 }
 
 .select-title-container {
-    margin: 28px 24px 200px 24px;
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
+  margin: 28px 24px 200px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
 }
 
 .book-tree-input-form__photo-container {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: absolute;
-    top: 230px;
-    left: 50%;
-    transform: translateX(-50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 230px;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .book-tree-input-form__large-input-container {
-    margin: 60px 24px 30px 24px;
+  margin: 60px 24px 30px 24px;
 }
 
 .book-tree-input-form__input-container {
-    margin: 60px 24px 30px 24px;
-    height: 110px;
+  margin: 60px 24px 30px 24px;
+  height: 110px;
 }
 
 .filter-tab-container {
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    background-color: rgba(0, 0, 0, 0.6);
-    z-index: 10;
-    position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 10;
+  position: fixed;
 }
 
 .book-tree-submit-container {
-    margin: 120px 24px 200px 24px;
+  margin: 120px 24px 200px 24px;
 }
 
 /* /tree/register/3-book-search-no-data.html */
@@ -108,11 +108,11 @@
 
 /*트리 생성 이미지 input 뒤에 초록색 배경*/
 .book-tree-input-form::before {
-    content: "";
-    display: block;
-    background-color: var(--main3, #e5eddb);
-    width: 100%;
-    height: 136px;
+  content: "";
+  display: block;
+  background-color: var(--main3, #e5eddb);
+  width: 100%;
+  height: 136px;
 }
 
 .btn-select-container {
@@ -133,62 +133,81 @@
 .margin-bottom160 {
   margin-bottom: 160px;
 }
+.margin-bottom500 {
+  margin-bottom: 500px;
+}
 
 /*
 home-tree__reg-4--search-book__input
 */
-.home-tree__reg-4--search-book{
-    padding-top: 28px;
-    padding-left: 24px;
-    padding-bottom: 48px;
-    font-size: 28px;
-    color: var(--main1, #323a27);
-    font-weight: var(--bold);
-    line-height: var(--line-height-main);
-    letter-spacing: var(--letter-spacing-main);
-
+.home-tree__reg-4--search-book {
+  padding-top: 28px;
+  padding-left: 24px;
+  padding-bottom: 48px;
+  font-size: 28px;
+  color: var(--main1, #323a27);
+  font-weight: var(--bold);
+  line-height: var(--line-height-main);
+  letter-spacing: var(--letter-spacing-main);
 }
-.home-tree__reg-4--search-book__input-container{
-    padding-top: 60px;
-    padding-left: 24px;
-    padding-right: 24px;
+.home-tree__reg-4--search-book__input-container {
+  padding-top: 60px;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 .tree-book-reg-search-book__title-container {
-    width: 100%;
-    margin-top: 28px;
-    margin-left: 24px;
-    margin-bottom: 48px;
-    display: flex;
-    justify-content: left;
+  width: 100%;
+  margin-top: 28px;
+  margin-left: 24px;
+  margin-bottom: 48px;
+  display: flex;
+  justify-content: left;
 }
-.tree-reg-cover-info__container{
-    width: 100%;
-    height: 326px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    position: relative;
+.tree-reg-cover-info__container {
+  width: 100%;
+  height: 326px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  position: relative;
 }
-.tree-reg-cover__container{
-    position: absolute;
-    height: 167px;
-    top: 0;
-}.tree-reg-book-info__container{
-    margin-top: 167px;
-    padding-top: 70px;
-    padding-left: 24px;
-    width: 100%;
-    height: 100px;
-    background: var(--main2--opacity40);
- }
- .tree-info-card__container{
-     padding-top: 40px;
-     padding-left: 24px;
- }
+.tree-reg-cover__container {
+  position: absolute;
+  height: 167px;
+  top: 0;
+}
+.tree-reg-book-info__container {
+  margin-top: 167px;
+  padding-top: 70px;
+  padding-left: 24px;
+  width: 100%;
+  height: 100px;
+  background: var(--main2--opacity40);
+}
+.tree-info-card__container {
+  padding-top: 40px;
+  padding-left: 24px;
+}
 
- .nav-container {
-     position: fixed;
-     width: 100%;
-     bottom: 0;
-     z-index: 10;
- }
+.nav-container {
+  position: fixed;
+  width: 100%;
+  bottom: 0;
+  z-index: 10;
+}
+
+/* /home/tree/search/list.html */
+.tree-card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  margin-left: 24px;
+  margin-right: 24px;
+}
+
+.tree-card-list::after {
+  content: " ";
+  display: block;
+  width: 100%;
+  height: 50px;
+}

--- a/src/main/resources/templates/component/filter/filter.css
+++ b/src/main/resources/templates/component/filter/filter.css
@@ -1,0 +1,33 @@
+/* =============================
+        나뭇잎 전체 검색
+         search-filter-log 
+    ============================== */
+
+.search-filter {
+  display: flex;
+  justify-content: flex-start;
+  gap: 10px;
+}
+
+.search-filter-log__checkbox-input {
+  display: none;
+}
+
+.search-filter-log__checkbox-input-text {
+  font-family: "Pretendard", serif;
+  font-size: 12px;
+  font-weight: var(--medium, 500);
+  color: var(--text-sub, #767676);
+  border-radius: 8px;
+  background-color: #f7f7f7;
+  padding: 12px 20px;
+  cursor: pointer;
+  user-select: none;
+  flex-shrink: 0;
+}
+
+.search-filter-log__checkbox-input:checked
+  + .search-filter-log__checkbox-input-text {
+  background-color: var(--main1, #323a27);
+  color: var(--white, #ffffff);
+}

--- a/src/main/resources/templates/component/filter/filter.html
+++ b/src/main/resources/templates/component/filter/filter.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>filter</title>
+    <link rel="stylesheet" href="./filter.css" />
+  </head>
+  <body>
+    <!-- =============================
+                나뭇잎 전체 검색
+                filter-search-log 
+        ============================== -->
+    <div class="search-filter-log">
+      <label class="search-filter-log__checkbox-labal" for="search-log-filter"
+        ><input
+          class="search-filter-log__checkbox-input"
+          type="checkbox"
+          id="search-log-filter"
+          name="log-filter"
+        />
+        <span class="search-filter-log__checkbox-input-text"
+          >나뭇잎 전체 검색</span
+        >
+      </label>
+    </div>
+    <!-- =============================
+               카테고리 필터 
+                filter-search-select
+        ============================== -->
+  </body>
+</html>

--- a/src/main/resources/templates/fragments/card.html
+++ b/src/main/resources/templates/fragments/card.html
@@ -1,19 +1,91 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" lang="ko">
-<body>
-
-<div th:fragment="tree-info-card(date, pagecount)">
-    <div class="card-tree-info">기본 정보</div>
-    <div class="card-tree-info__frame">
+  <body>
+    <!-- ================ -->
+    <!-- tree-info-card -->
+    <!-- ================ -->
+    <div th:fragment="tree-info-card(date, pagecount)">
+      <div class="card-tree-info">기본 정보</div>
+      <div class="card-tree-info__frame">
         <div>
-            <p class="card-tree-info__title">발행(출시)일자</p>
-            <p class="card-tree-info__title">쪽수</p>
+          <p class="card-tree-info__title">발행(출시)일자</p>
+          <p class="card-tree-info__title">쪽수</p>
         </div>
         <div>
-            <p class="card-tree-info__content" th:text="${date}"></p>
-            <p class="card-tree-info__content" th:text="${pagecount}"></p>
+          <p class="card-tree-info__content" th:text="${date}"></p>
+          <p class="card-tree-info__content" th:text="${pagecount}"></p>
         </div>
+      </div>
     </div>
-</div>
-</body>
+
+    <!-- ================ -->
+    <!-- tree card -->
+    <!-- ================ -->
+    <div
+      class="card-tree-details"
+      th:fragment="card-tree-details(tree)"
+      th:object="${tree}"
+    >
+      <a class="card-tree-detail">
+        <img
+          class="card-tree__book-cover"
+          src="/src/main/resources/static/svg/card-felt__cover.svg"
+          th:with="url = *{imgUrl}"
+          th:src="@{/svg/card-felt__cover.svg}"
+        />
+        <div class="card-tree-detail__box">
+          <!--반복문으로 넣어야 할듯..-->
+          <div class="card-tree-detail__tags">
+            <span class="card-tree-detail__tag" id="data-XXX">도서</span>
+            <span class="card-tree-detail__tag" id="data-XXX">정치비평</span>
+          </div>
+          <!---->
+          <p class="card-tree-detail__name" id="data-XXX" th:text="*{bookName}">
+            운명이란 무엇인가?
+            <img
+              class="card-tree-detail__complete-icon"
+              th:if="{*{complete} == true}"
+              src="/src/main/resources/static/svg/card-tree-details-complete.svg"
+              alt="완독"
+            />
+          </p>
+          <p
+            class="card-tree-detail__explanation"
+            id="data-XXX"
+            th:text="*{description}"
+          >
+            그의 운명에 대한 아주 개인적인 생각
+          </p>
+          <div class="card-tree-detail__info">
+            <span
+              class="card-tree-detail__info"
+              id="data-XXX"
+              th:text="*{createdAt}"
+              >2024</span
+            >
+            <span class="card-tree-detail__info">/</span>
+            <span
+              class="card-tree-detail__info"
+              id="data-XXX"
+              th:text="*{author}"
+              >유시민</span
+            >
+            <span class="card-tree-detail__info">/</span>
+            <span
+              class="card-tree-detail__info"
+              id="data-XXX"
+              th:text="*{publisher}"
+              >생각의 길</span
+            >
+          </div>
+          <span
+            class="card-tree-detail__info-created-date"
+            id="data-XXX"
+            th:text="*{updatedAt}"
+            >2024-07-15</span
+          >
+        </div>
+      </a>
+    </div>
+  </body>
 </html>

--- a/src/main/resources/templates/fragments/filter.html
+++ b/src/main/resources/templates/fragments/filter.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="https://www.thymeleaf.org">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>filter</title>
+  </head>
+  <body>
+    <!-- =============================
+                나뭇잎 전체 검색
+                filter-search-log 
+        ============================== -->
+    <div class="search-filter-log" th:fragment="search-filter-log(text)">
+      <label class="search-filter-log__checkbox-labal" for="search-log-filter"
+        ><input
+          class="search-filter-log__checkbox-input"
+          type="checkbox"
+          id="search-log-filter"
+          name="log-filter"
+        />
+        <span class="search-filter-log__checkbox-input-text" th:text="${text}"
+          >나뭇잎 전체 검색</span
+        >
+      </label>
+    </div>
+  </body>
+</html>

--- a/src/main/resources/templates/fragments/input.html
+++ b/src/main/resources/templates/fragments/input.html
@@ -108,8 +108,8 @@
     </div>
 
     <!-- ===================================
-                input-back-search
-            검색버튼 - 뒤로 가기 버튼 있음. 
+                input-back-search - anchor
+            검색버튼 - 뒤로 가기 버튼 있음. - 앵커버전
       ==================================== -->
     <div
       class="search__form"
@@ -141,14 +141,63 @@
       </form>
     </div>
 
-<!--  ==========================================
+    <!-- ===================================
+                input-back-search - input
+            검색버튼 - 뒤로 가기 버튼 있음. - text input(post)버전
+      ==================================== -->
+    <div
+      class="search__form"
+      th:fragment="input-back-search-text(placeholder, action, name)"
+    >
+      <div>
+        <a href="#">
+          <img
+            src="/src/main/resources/static/svg/back.svg"
+            th:src="@{/svg/back.svg}"
+            alt="back button"
+          />
+        </a>
+      </div>
+      <form class="search-bar" action="" th:action="${action}" method="post">
+        <label class="search-bar--label">
+          <input
+            class="search-bar--input"
+            type="text"
+            th:name="${name}"
+            th:id="${name}"
+            th:placeholder="${placeholder}"
+            autocomplete="off"
+          />
+          <button class="search-bar--close" type="reset">
+            <img
+              src="/src/main/resources/static/svg/close-button.svg"
+              th:src="@{/svg/close-button.svg}"
+              alt="close-btn"
+            />
+          </button>
+        </label>
+        <button type="submit">
+          <img
+            src="/src/main/resources/static/svg/lens.svg"
+            th:src="@{/svg/lens.svg}"
+            alt="lens"
+          />
+        </button>
+      </form>
+    </div>
+
+    <!--  ==========================================
       FRAGMENT: 고정 데이터 화면에 안보임
       ========================================== -->
-      <div class="input-none none" th:fragment="default-data(name, value)">
-        <label class="input-none__label">
-          <input class="input-none__input" type="text" th:name="${name}" th:value="${value}" />
-        </label>
-      </div>
-
+    <div class="input-none none" th:fragment="default-data(name, value)">
+      <label class="input-none__label">
+        <input
+          class="input-none__input"
+          type="text"
+          th:name="${name}"
+          th:value="${value}"
+        />
+      </label>
+    </div>
   </body>
 </html>

--- a/src/main/resources/templates/fragments/top-bar.html
+++ b/src/main/resources/templates/fragments/top-bar.html
@@ -30,5 +30,19 @@
       <span class="top-bar-search-result-number">개</span>
       <p class="top-bar-search-result-text">의 검색 결과</p>
     </div>
+    <!-- =========================
+       topbar-search-result-num
+            검색 결과 개수  - 최신순 정렬 버튼
+    ========================== -->
+    <div
+      class="top-bar-search-result-num"
+      th:fragment="topbar-search-result-num-recent(num)"
+    >
+      <p class="top-bar-search-result-number" id="data-XXX" th:text="${num}">
+        10
+      </p>
+      <span class="top-bar-search-result-number">개</span>
+      <p class="top-bar-search-result-text">의 검색 결과</p>
+    </div>
   </body>
 </html>

--- a/src/main/resources/templates/view/home/index.html
+++ b/src/main/resources/templates/view/home/index.html
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="ko" xmlns="https://www.thymeleaf.org">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"/>
-    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <meta
+      name="viewport"
+      content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0"
+    />
 
-    <link rel="stylesheet" href="../../../static/css/reset.css" />
-    <link rel="stylesheet" href="../../../static/css/styles.css" />
+    <link rel="stylesheet" th:href="@{/css/reset.css}" />
+    <link rel="stylesheet" th:href="@{/css/styles.css}" />
 
-    <title>Document</title>
+    <title>home</title>
   </head>
   <body>
     <header>
@@ -20,7 +22,11 @@
           <a class="search__link" href="#">
             <div class="search__input-box">
               <p class="search__placeholder">나의 트리 검색</p>
-              <img class="search__icon" src="../../../static/svg/lens.svg" alt="lens.svg" />
+              <img
+                class="search__icon"
+                th:src="../../../static/svg/lens.svg"
+                alt="lens.svg"
+              />
             </div>
           </a>
         </div>
@@ -44,15 +50,28 @@
             <!-- 컴포넌트 start -->
             <div class="book-img">
               <ul class="book-img__list">
-                  <li class="book-img__item">
-                    <img class="book-img__image" src="../../../static/img/home/home-left-book.png" alt="" />
-                  </li>
-                  <li class="book-img__item">
-                    <img class="book-img__image" class="mid-img" src="../../../static/img/home/home-mid-book.png" alt="" />
-                  </li>
-                  <li class="book-img__item">
-                    <img class="book-img__image" src="../../../static/img/home/home-right-book.png" alt="" />
-                  </li>
+                <li class="book-img__item">
+                  <img
+                    class="book-img__image"
+                    src="../../../static/img/home/home-left-book.png"
+                    alt=""
+                  />
+                </li>
+                <li class="book-img__item">
+                  <img
+                    class="book-img__image"
+                    class="mid-img"
+                    src="../../../static/img/home/home-mid-book.png"
+                    alt=""
+                  />
+                </li>
+                <li class="book-img__item">
+                  <img
+                    class="book-img__image"
+                    src="../../../static/img/home/home-right-book.png"
+                    alt=""
+                  />
+                </li>
               </ul>
             </div>
             <!-- 컴포넌트 end -->
@@ -79,18 +98,14 @@
                 </div>
                 <div class="book-info-container__year">2024.07.15</div>
               </div>
-              
 
               <!-- 컴포넌트 end -->
             </section>
 
             <!-- 컴포넌트 end -->
           </section>
-
         </section>
       </section>
     </main>
-
-
   </body>
 </html>

--- a/src/main/resources/templates/view/home/no-tree.html
+++ b/src/main/resources/templates/view/home/no-tree.html
@@ -1,64 +1,51 @@
 <!DOCTYPE html>
 <html lang="en" xmlns:th="http://www.thymeleaf.org">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <link th:href="@{/css/reset.css}" rel="stylesheet" />
-  <link th:href="@{/css/fragments.css}" rel="stylesheet" />
-  <link th:href="@{/css/layout.css}" rel="stylesheet" />
+    <link th:href="@{/css/reset.css}" rel="stylesheet" />
+    <link th:href="@{/css/fragments.css}" rel="stylesheet" />
+    <link th:href="@{/css/layout.css}" rel="stylesheet" />
 
+    <title>나의 트리</title>
+  </head>
+  <body>
+    <header>
+      <h1 class="none">나의 트리</h1>
+      <section class="header-search-container">
+        <h1 class="none">나의 트리 검색 링크</h1>
+        <div th:replace="fragments/header :: header-search-link"></div>
+      </section>
+    </header>
 
-  <title>나의 트리</title>
-</head>
-<body>
+    <main>
+      <section class="my-tree-container">
+        <h1 class="none">나의 트리 정보</h1>
 
-  <header>
-    <h1 class="none">나의 트리</h1>
-    <section class="header-search-container">
-      <h1 class="none">나의 트리 검색 링크</h1>
-      <div th:replace="fragments/header :: header-search-link"></div>
-    </section>
-  </header>
+        <section class="my-tree-title-container">
+          <h1
+            th:replace="fragments/text :: text-main-title('나의 트리', 28)"
+          ></h1>
+        </section>
 
-  <main>
-    <section class="my-tree-container">
-      <h1 class="none">나의 트리 정보</h1>
-
-      <section class="my-tree-title-container">
-        <h1 th:replace="fragments/text :: text-main-title('나의 트리')"></h1>
+        <section class="book-img-container">
+          <h1 class="none">트리 이미지</h1>
+          <div th:replace="fragments/background :: bg-no-tree-book"></div>
+        </section>
       </section>
 
-      <section class="book-img-container">
-        <h1 class="none">트리 이미지</h1>
-        <div th:replace="fragments/background :: bg-no-tree-book"></div>
+      <section class="btn-full-width-link-container">
+        <h1 class="none">트리 생성 버튼</h1>
+        <div
+          th:replace="fragments/button :: link-full-width(link='#', text='트리 생성')"
+        ></div>
       </section>
+    </main>
 
-      <section class="link-btn-container">
-        <h2 class="none">트리 생성 버튼</h2>
-        <!-- 컴포넌트 start -->
-        <div class="btn-box">
-          <a class="btn-box__link" href="">
-            <div class="btn-box__btn">
-                <p class="btn-box__placeholder">트리 생성</p>
-            </div>
-          </a>
-        </div>
-        <!-- 컴포넌트 end -->
-      </section>
-
-    </section>
-
-    <section class="btn-full-width-link-container">
-      <h1 class="none">트리 생성 버튼</h1>
-      <div th:replace="fragments/button :: link-full-width(link='#', text='트리 생성')"></div>
-    </section>
-  </main>
-
-  <aside class="nav-container">
-    <h1 class="none">네비게이션 하단</h1>
-    <nav th:replace="fragments/nav :: navigation-bar(active='home')"></nav>
-  </aside>
-
-</body>
+    <aside class="nav-container">
+      <h1 class="none">네비게이션 하단</h1>
+      <nav th:replace="fragments/nav :: navigation-bar(active='home')"></nav>
+    </aside>
+  </body>
 </html>

--- a/src/main/resources/templates/view/home/tree/search/index.html
+++ b/src/main/resources/templates/view/home/tree/search/index.html
@@ -4,8 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <link th:href="@{/css/reset.css}" rel="stylesheet" />
-    <link th:href="@{/css/styles.css}" rel="stylesheet" />
+    <link th:href="@{/common/variables.css}" rel="stylesheet" />
+    <link th:href="@{/css/fragments.css}" rel="stylesheet" />
+    <link th:href="@{/css/layout.css}" rel="stylesheet" />
 
     <title>나의 트리 검색</title>
   </head>
@@ -13,235 +14,33 @@
   <body>
     <header>
       <h1 class="none">나의 트리</h1>
-      <form class="back-search__form">
-        <section class="back-search-container">
-          <h1 class="none">트리 검색</h1>
-          <!-- 컴포넌트 start -->
-          <div class="back-search">
-            <a class="back-search__back-link" th:href="@{/home}">
-              <div class="back-search__icon-box">
-                <img
-                  class="back-search__icon"
-                  th:src="@{/svg/back-icon.svg}"
-                  alt=""
-                />
-              </div>
-            </a>
-            <div class="back-search__input-box">
-              <input
-                class="back-search__input-text"
-                type="text"
-                placeholder="트리 이름을 작성해주세요"
-              />
-              <img
-                class="back-search__lens-icon"
-                th:src="@{/svg/lens.svg}"
-                alt=""
-              />
-            </div>
-          </div>
-          <!-- 컴포넌트 end -->
-        </section>
+      <section class="reg-book-search-container">
+        <h2 class="none">트리 검색</h2>
+        <!-- 컴포넌트 start -->
+        <div
+          th:replace="~{fragments/input::input-back-search-text(placeholder='검색할 트리를 입력해주세요', action='', name='treeSearchText')}"
+        ></div>
+      </section>
 
-        <section class="search-filter-container">
-          <h1 class="none">트리 검색 필터</h1>
+      <section>
+        <h2 class="none">검색 필터 리스트</h2>
+        <!-- 컴포넌트 start -->
+      </section>
 
-          <section class="search-check-box-container">
-            <h1 class="none">검색 범위 체크박스</h1>
-            <!-- 컴포넌트 start -->
-            <div class="search-filter-log">
-              <label
-                class="search-filter-log__checkbox-labal"
-                for="search-log-filter"
-                ><input
-                  class="search-filter-log__checkbox-input"
-                  type="checkbox"
-                  id="search-log-filter"
-                  name="log-filter"
-                />
-                <span class="search-filter-log__checkbox-input-text"
-                  >나뭇잎 전체 검색</span
-                >
-              </label>
-            </div>
-            <!-- 컴포넌트 end -->
-          </section>
-
-          <section class="community-tab-bar__filter-btn-box">
-            <h1 class="none">필터 리스트</h1>
-            <!-- 컴포넌트 start -->
-            <ul class="community-tab-bar__filter-btn-list">
-              <li class="community-tab-bar__filter-btn-item">
-                <button class="community-tab-bar__filter-btn--white">
-                  카테고리
-                  <svg
-                    width="12"
-                    height="7"
-                    viewBox="0 0 12 7"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M0.799805 1.2998L5.80062 5.8798L10.7998 1.2998"
-                      stroke="#767676"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    />
-                  </svg>
-                </button>
-
-                <section class="community-tab-bar__filter-tab-box none">
-                  <div class="community-tab-bar__filter-tab-list">
-                    <header class="community-tab-bar__filter-tab-header">
-                      <button class="community-tab-bar__filter-tab-back-btn">
-                        <img src="@{/svg/tab-back.svg}" alt="뒤로가기 버튼" />
-                      </button>
-                      <h1 class="community-tab-bar__filter-tab-title">
-                        카테고리 필터
-                      </h1>
-                    </header>
-                    <ul class="community-tab-bar__filter-list">
-                      <li class="community-tab-bar__filter-item">
-                        <label class="community-tab-bar__filter-item-label">
-                          <input
-                            class="community-tab-bar__filter-item-radio"
-                            type="radio"
-                            name="filter"
-                            value="logs"
-                            checked
-                          />
-                          <span
-                            class="community-tab-bar__filter-item-label-text"
-                            >필터 정보</span
-                          >
-                          <div class="community-tab-bar__filter-icon">
-                            <img
-                              class="community-tab-bar__filter-icon-img"
-                              src="@{/svg/tab-check-btn.svg}"
-                              alt="필터 버튼"
-                            />
-                          </div>
-                        </label>
-                      </li>
-                      <li class="community-tab-bar__filter-item">
-                        <label class="community-tab-bar__filter-item-label">
-                          <input
-                            class="community-tab-bar__filter-item-radio"
-                            type="radio"
-                            name="filter"
-                            value="logs"
-                          />
-                          <span
-                            class="community-tab-bar__filter-item-label-text"
-                            >필터 정보</span
-                          >
-                          <div class="community-tab-bar__filter-icon">
-                            <img
-                              class="community-tab-bar__filter-icon-img"
-                              src="@{/svg/tab-check-btn.svg}"
-                              alt="필터 버튼"
-                            />
-                          </div>
-                        </label>
-                      </li>
-                    </ul>
-                  </div>
-                </section>
-              </li>
-            </ul>
-            <!-- 컴포넌트 end -->
-          </section>
-        </section>
-
-        <section class="filter-statistics-container">
-          <h1 class="none">리스트 결과 페이지</h1>
-          <!-- 컴포넌트 start -->
-          <div class="filter-statistics-bar">
-            <p class="filter-statistics-bar__list-count">
-              <span class="filter-statistics-bar__list-count-num">0</span>개의
-              검색결과
-            </p>
-            <button class="filter-statistics-bar__list-sort-btn">
-              최근 수정한 순
-              <svg
-                width="5"
-                height="8"
-                viewBox="0 0 5 8"
-                fill="none"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M1 0.5L4 4L1 7.5"
-                  stroke="#767676"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                />
-              </svg>
-            </button>
-          </div>
-          <!-- 컴포넌트 end -->
-
-          <section class="정렬 필터 리스트 none">
-            <!-- 컴포넌트 start -->
-            <!-- 컴포넌트 end -->
-          </section>
-        </section>
-      </form>
+      <section>
+        <h1 class="none">검색 결과 및 최근 수정한 순</h1>
+        <!-- 컴포넌트 start -->
+      </section>
     </header>
 
     <main>
       <section class="search-tree-list-container">
-        <h1 class="none">트리 검색 목록</h1>
+        <h1 class="none">트리 검색 결과</h1>
       </section>
     </main>
 
     <aside>
       <!-- 컴포넌트 start -->
-      <nav class="main-nav">
-        <ul class="main-nav__list">
-          <a class="main-nav__link" href="">
-            <li class="main-nav__item">
-              <img
-                class="main-nav__icon"
-                th:src="@{/svg/nav-home--active.svg}"
-                alt=""
-              />
-              <p class="main-nav__text--active">홈</p>
-            </li>
-          </a>
-          <a class="main-nav__link" href="">
-            <li class="main-nav__item">
-              <img
-                class="main-nav__icon"
-                th:src="@{/svg/nav-search.svg}"
-                alt=""
-              />
-              <p class="main-nav__text">탐색</p>
-            </li>
-          </a>
-          <a class="main-nav__link" href="">
-            <li class="main-nav__item">
-              <img
-                class="main-nav__icon"
-                th:src="@{/svg/nav-cummunity.svg}"
-                alt=""
-              />
-              <p class="main-nav__text">커뮤니티</p>
-            </li>
-          </a>
-          <a class="main-nav__link" href="">
-            <li class="main-nav__item">
-              <img
-                class="main-nav__icon"
-                th:src="@{/svg/nav-mypage.svg}"
-                alt=""
-              />
-              <p class="main-nav__text">나의 꼬깃</p>
-            </li>
-          </a>
-        </ul>
-      </nav>
-      <!-- 컴포넌트 end -->
     </aside>
   </body>
 </html>

--- a/src/main/resources/templates/view/home/tree/search/index.html
+++ b/src/main/resources/templates/view/home/tree/search/index.html
@@ -43,6 +43,8 @@
       </section>
     </main>
 
-    <aside><div th:replace="~{fragments/nav :: navigation-bar(home)}"</aside>
+    <aside class="nav-container">
+      <div th:replace="~{fragments/nav :: navigation-bar(home)}"
+    </aside>
   </body>
 </html>

--- a/src/main/resources/templates/view/home/tree/search/tree-list.html
+++ b/src/main/resources/templates/view/home/tree/search/tree-list.html
@@ -30,7 +30,7 @@
       </section>
 
       <section>
-        <h1 class="none">검색 결과 및 최근 수정한 순서</h1>
+        <h2 class="none">검색 결과 개수 및 최근 수정한 순서</h2>
         <div
           th:replace="~{fragments/top-bar::topbar-search-result-num(*{size})}"
         ></div>
@@ -38,16 +38,27 @@
     </header>
 
     <main>
+      <h2 class="none">트리 검색 결과</h2>
       <section class="tree-card-list">
-        <h1 class="none">트리 검색 결과</h1>
+        <h3 class="none">트리 검색 리스트</h3>
         <div th:each="tree : *{values}">
           <div
             th:replace="~{fragments/card::card-tree-details(tree = ${tree})}"
           ></div>
         </div>
       </section>
+      <section>
+        <h3 class="none">검색 결과 없음</h3>
+        <div
+          class="margin-bottom500"
+          th:if="*{size} eq 0"
+          th:insert="~{fragments/text::text-info(text = '검색 결과가 없습니다.', boldText='다시 검색해 주세요' )}"
+        ></div>
+      </section>
     </main>
 
-    <aside><div th:replace="~{fragments/nav :: navigation-bar(home)}"</aside>
+    <aside class="nav-container">
+      <div th:replace="~{fragments/nav :: navigation-bar(home)}"
+    </aside>
   </body>
 </html>

--- a/src/main/resources/templates/view/home/tree/search/tree-list.html
+++ b/src/main/resources/templates/view/home/tree/search/tree-list.html
@@ -11,7 +11,7 @@
     <title>나의 트리 검색</title>
   </head>
 
-  <body>
+  <body th:object="${resultMap}">
     <header class="reg-book-search-container">
       <h1 class="none">나의 트리</h1>
       <section>
@@ -32,14 +32,19 @@
       <section>
         <h1 class="none">검색 결과 및 최근 수정한 순서</h1>
         <div
-          th:replace="~{fragments/top-bar::topbar-search-result-num(0)}"
+          th:replace="~{fragments/top-bar::topbar-search-result-num(*{size})}"
         ></div>
       </section>
     </header>
 
     <main>
-      <section class="margin-bottom500">
+      <section class="tree-card-list">
         <h1 class="none">트리 검색 결과</h1>
+        <div th:each="tree : *{values}">
+          <div
+            th:replace="~{fragments/card::card-tree-details(tree = ${tree})}"
+          ></div>
+        </div>
       </section>
     </main>
 


### PR DESCRIPTION
### 고려해야할 이슈
1. 나중에 아래로 스크롤할때는 하단 nav가 보이지 않게 기능을 추가할 예정이더라도, 애초에 하단 nav와 겹치는 화면 최하단의 버튼이나, 화면이 있으면 안될 것 같습니다.
2. 그래서 지금까지 작업한 페이지는 `::after` 로 임시로 빈 공간들을 만들어 두었습니다.
3. 그런데 하단 nav가 들어가는 페이지마다 `::after` 로 뒤의 빈 공간을 만들어줘야 하는건 비효율적인 것 같습니다. 
4. 이를 하나의 css 스타일이나, 컴포넌트로 관리하는게 나을 듯 한데 의견부탁드립니다.

### 추가된 페이지
1. TreeController로 동작하는 home/tree/search 페이지 추가
2. 트리 더미 데이터 생성하려면, 컨트롤러에서 `Tree.createTestTree()`를 이용하시면 됩니다. 아직은 DB단이 없기 때문에 메모리를 이용해야 합니다.