### PR TITLE
Add: 이메일 통한 회원가입 임시 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+    // https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-mail
+    implementation 'org.springframework.boot:spring-boot-starter-mail:3.3.3'
     testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.3'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/src/main/java/Recorders/ggogit/domain/member/entity/MemberJoinEmail.java
+++ b/src/main/java/Recorders/ggogit/domain/member/entity/MemberJoinEmail.java
@@ -1,0 +1,13 @@
+package Recorders.ggogit.domain.member.entity;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberJoinEmail {
+
+    private String to;
+    private String subject;
+    private String body;
+}

--- a/src/main/java/Recorders/ggogit/domain/member/service/EmailService.java
+++ b/src/main/java/Recorders/ggogit/domain/member/service/EmailService.java
@@ -1,0 +1,22 @@
+package Recorders.ggogit.domain.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender emailSender;
+
+    public void sendEmail(String email) {
+
+        String setForm = "rhkddlr98@naver.com"; //보내는 사람
+        String toEmail = email; //받는 사람
+        String title = "ggogit 회원가입 페이지"; //제목
+
+    }
+}

--- a/src/main/java/Recorders/ggogit/domain/member/service/EmailService.java
+++ b/src/main/java/Recorders/ggogit/domain/member/service/EmailService.java
@@ -1,9 +1,19 @@
 package Recorders.ggogit.domain.member.service;
 
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -12,11 +22,35 @@ public class EmailService {
 
     private final JavaMailSender emailSender;
 
-    public void sendEmail(String email) {
+    public void sendEmail(String email) throws MessagingException {
 
-        String setForm = "rhkddlr98@naver.com"; //보내는 사람
-        String toEmail = email; //받는 사람
-        String title = "ggogit 회원가입 페이지"; //제목
+        //발신자, 수신자, 제목 설정
+        MimeMessage mimeMessage = emailSender.createMimeMessage();
+        mimeMessage.setFrom(new InternetAddress("rhkddlr9899@gmail.com"));
+        mimeMessage.addRecipients(Message.RecipientType.TO, String.valueOf(new InternetAddress(email)));
+        mimeMessage.setSubject("꼬깃 회원가입 URL 안내");
 
+        //본문
+        mimeMessage.setContent("<html><h1 style='color:#323a27'>꼬깃에 오신걸 환영합니다!<h1></br><h3>아래의 링크로 접속해 회원가입을 진행해 주세요!<h3></br><a target='_blank' href='http://ggogit.io/member/join-input'>꼬깃 회원가입 바로 가기</a></html>", "text/html; charset=utf-8" );
+        emailSender.send(mimeMessage);
+
+    }
+    public void createEmailCookie(HttpServletResponse response, String email) {
+        Cookie cookie = new Cookie("ggogitEmail", email);
+        //회원가입 페이지에만 쿠키를 보내도록 설정
+        cookie.setPath("/member/join-input");
+        cookie.setMaxAge(10*60); //10분동안 쿠키 유지
+        response.addCookie(cookie);
+    }
+
+    public Optional<String> getEmailCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        Optional<String> emailCookie = Optional.empty();
+        for (Cookie cookie : cookies) {
+            if(cookie.getName().equals("ggogitEmail")) {
+                emailCookie = Optional.ofNullable(cookie.getValue());
+            }
+        }
+        return emailCookie;
     }
 }

--- a/src/main/java/Recorders/ggogit/domain/member/service/LoginService.java
+++ b/src/main/java/Recorders/ggogit/domain/member/service/LoginService.java
@@ -3,11 +3,11 @@ package Recorders.ggogit.domain.member.service;
 import Recorders.ggogit.domain.member.entity.Member;
 import Recorders.ggogit.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
-import java.util.regex.Pattern;
 
 @Transactional
 @Service
@@ -41,7 +41,5 @@ public class LoginService {
         Optional<Member> member = Optional.ofNullable(memberRepository.findByNickname(nickname));
         return member.orElse(null);
     }
-
-
 
 }

--- a/src/main/java/Recorders/ggogit/domain/member/service/LoginService.java
+++ b/src/main/java/Recorders/ggogit/domain/member/service/LoginService.java
@@ -2,11 +2,15 @@ package Recorders.ggogit.domain.member.service;
 
 import Recorders.ggogit.domain.member.entity.Member;
 import Recorders.ggogit.domain.member.repository.MemberRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.Optional;
 
 @Transactional
@@ -28,7 +32,6 @@ public class LoginService {
 
     public Member RegMember(Member member) {
         memberRepository.save(member);
-
         return member;
     }
 

--- a/src/main/java/Recorders/ggogit/web/member/controller/MemberController.java
+++ b/src/main/java/Recorders/ggogit/web/member/controller/MemberController.java
@@ -94,15 +94,15 @@ public class MemberController {
 
     @GetMapping("/join-input")
     public String getMemberJoinInput(Model model, HttpServletRequest request) {
-        LoginForm loginForm = new LoginForm();
+        LoginRegForm loginRegForm = new LoginRegForm();
         Optional<String> emailCookie = emailService.getEmailCookie(request);
 
         //만약 /member/join에서 입력한 쿠키가 있다면 쿠키에서 이메일 값을 받아서 모델에 전송해준다.
         //뷰에서는 전송받은 email은 read-only로 처리해준다.
         if(emailCookie.isPresent()){
-            loginForm.setEmail(emailCookie.get());
+            loginRegForm.setEmail(emailCookie.get());
         }
-        model.addAttribute("loginRegForm", loginForm);
+        model.addAttribute("loginRegForm", loginRegForm);
         return "view/member/join-input";
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,19 @@ spring:
   servlet:
     multipart:
       max-file-size: 10MB
+    ## 메일 발송
+  mail:
+    host: smtp.gmail.com #SMTP 서버 호스트
+    port: 587 # SMTP 서버 포트
+    username:  # SMTP 서버 로그인 아이디
+    password:  #SMTP 서버 비밀번호
+    properties:
+      mail:
+        smtp:
+          auth: true #사용자 인증 시도 여부(기본값은 false)
+          timeout: 5000 #socket read timeout
+          starttls:
+            enable: true #starttls 활성화 여부
 server:
   servlet:
     session:
@@ -29,4 +42,5 @@ logging:
   level:
     Recorders.ggogit.domain: trace
     org.springframework.jdbc: trace
+
 

--- a/src/main/resources/templates/view/member/join-input.html
+++ b/src/main/resources/templates/view/member/join-input.html
@@ -42,7 +42,7 @@
                 <div class="input-text__bar">
                     <label class="input-text__label">
                         <span class="input-text__label-text" th:text="'이메일'">이메일</span>
-                        <input class="input-text__input" th:field="*{email}" th:placeholder="'(필수)이메일을 입력해주세요'" autocomplete="off"/>
+                        <input class="input-text__input" th:field="*{email}" th:placeholder="'(필수)이메일을 입력해주세요'" autocomplete="off" readonly/>
                     </label>
                     <div th:errors="*{email}" class="text--errors"></div>
                 </div>


### PR DESCRIPTION
###이메일 통한 회원가입 임시 구현 완료

구글의 SMTP서버를 대신 이용했습니다.
로컬환경에선 해당 기능이 돌아가지 않습니다. application.yml에 SMTP 아이디, 비밀번호를 입력하지 않은 상태입니다.
다만 ggogit.io접속해서는 해당 기능이 가능합니다.

이를 위해 EmailService 구현했습니다. 해당 서비스에는 이메일 전송, 이메일 전송시 입력한 이메일 문자열 쿠키에 담았다가, 회원가입 페이지(join-input)에서 가져와 값 채우는 기능이 있습니다.