### PR TITLE
[기능] #213 홈 화면 구현 완료

### DIFF
--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
@@ -223,4 +223,15 @@ public class TreeController {
 
         return new ResponseEntity<>(TreeInfoResponseHome.of(treeInfoResponseList), HttpStatus.OK);
     }
+
+    @GetMapping("tree-home-sort")
+    public ResponseEntity<TreeInfoResponseHome> getTreeInfoResponsesSort(
+            @RequestParam(value = "mid",defaultValue = "1") Long mid,
+            @RequestParam(value = "s", required = false) Long seedId
+    ) {
+        Long memberId = mid;
+        List<TreeInfoResponse> treeInfoResponseList = treeService.findTreeInfoResponseList(memberId, seedId);
+
+        return new ResponseEntity<>(TreeInfoResponseHome.of(treeInfoResponseList), HttpStatus.OK);
+    }
 }

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
@@ -227,7 +227,7 @@ public class TreeController {
     @GetMapping("tree-home-sort")
     public ResponseEntity<TreeInfoResponseHome> getTreeInfoResponsesSort(
             @RequestParam(value = "mid",defaultValue = "1") Long mid,
-            @RequestParam(value = "s", required = false) Long seedId
+            @RequestParam(value = "seedId", required = false) Long seedId
     ) {
         Long memberId = mid;
         List<TreeInfoResponse> treeInfoResponseList = treeService.findTreeInfoResponseList(memberId, seedId);

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
@@ -204,16 +204,23 @@ public class TreeController {
         return leafList.stream().sorted(comparator).collect(Collectors.toList());
     }
 
+    //Access Token을 받아서 TreeInfoResponseHome을 반환하는 API
 //    @GetMapping("tree-home")
 //    public ResponseEntity<TreeInfoResponseHome> getTreeInfoResponses(
 //       @RequestHeader(value="Authorization") String accessToken) {
 //
 //        Long memberId = jwtTokenProvider.getMemberIdFromToken(accessToken);
-//        List<Tree> trees = treeService.findAllByMemberId(memberId);
+//        List<TreeInfoResponse> treeInfoResponseList = treeService.findTreeInfoResponseList(memberId);
 //
-//        for(Tree tree : trees){
-//            TreeInfoResponse.of(tree, )
-//        }
-//
+//        return new ResponseEntity<>(TreeInfoResponseHome.of(treeInfoResponseList), HttpStatus.OK);
 //    }
+    @GetMapping("tree-home")
+    public ResponseEntity<TreeInfoResponseHome> getTreeInfoResponses(
+            @RequestParam(value = "mid",defaultValue = "1") Long mid) {
+
+        Long memberId = mid;
+        List<TreeInfoResponse> treeInfoResponseList = treeService.findTreeInfoResponseList(memberId);
+
+        return new ResponseEntity<>(TreeInfoResponseHome.of(treeInfoResponseList), HttpStatus.OK);
+    }
 }

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeInfoResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeInfoResponse.java
@@ -1,10 +1,7 @@
 package io.ggogit.ggogit.api.tree.dto;
 
 import io.ggogit.ggogit.domain.tree.entity.Tree;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,8 +11,10 @@ import java.time.format.DateTimeFormatter;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
+@ToString(of = {"bookId", "bookCategory", "bookTitle", "bookAuthor", "bookTranslator", "bookPublisher", "bookPublishedYear", "bookTotalPage", "treeId", "memberId", "seedId", "title", "description", "visibility", "leafCreatedAt", "createdAt", "readingPage", "coverImageName", "treeLeafCnt", "treeLikeCnt", "treeViewCnt"})
 public class TreeInfoResponse {
 
+    //books
     private Long bookId;
     private String bookCategory;
     private String bookTitle;
@@ -24,9 +23,11 @@ public class TreeInfoResponse {
     private String bookPublisher;
     private String bookPublishedYear;
     private Integer bookTotalPage;
+    //relationship identifiers
     private Long treeId;
     private Long memberId ;
     private Long seedId;
+    //trees
     private String title;
     private String description;
     private Boolean visibility;
@@ -34,6 +35,7 @@ public class TreeInfoResponse {
     private String  createdAt;
     private Integer readingPage ;
     private String coverImageName;
+    //computed
     private Long treeLeafCnt;
     private Long treeLikeCnt;
     private Long treeViewCnt;

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeInfoResponseHome.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeInfoResponseHome.java
@@ -1,16 +1,20 @@
 package io.ggogit.ggogit.api.tree.dto;
 
+import lombok.Builder;
 import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Builder
 public class TreeInfoResponseHome {
 
-    private final List<TreeInfoResponse> treeInfoResponseList = new ArrayList<>();
+    private List<TreeInfoResponse> treeInfoResponseList = new ArrayList<>();
 
-    public void addTreeInfoResponse(TreeInfoResponse treeInfoResponse) {
-        treeInfoResponseList.add(treeInfoResponse);
+    public static TreeInfoResponseHome of(List<TreeInfoResponse> treeInfoResponseList) {
+        return TreeInfoResponseHome.builder()
+                .treeInfoResponseList(treeInfoResponseList)
+                .build();
     }
 }

--- a/backend-2/src/main/java/io/ggogit/ggogit/config/ModelMapperConfig.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/config/ModelMapperConfig.java
@@ -1,0 +1,14 @@
+package io.ggogit.ggogit.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ModelMapperConfig {
+
+    @Bean
+    public ModelMapper modelMapper() {
+        return new ModelMapper();
+    }
+}

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/leaf/entity/Leaf.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/leaf/entity/Leaf.java
@@ -27,6 +27,7 @@ import java.time.LocalDateTime;
 @SQLRestriction("is_deleted = false")
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "LEAF")
+@ToString(of={"id", "title", "content", "viewCount", "likeCount", "childLeafCount"})
 public class Leaf {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/entity/Tree.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/entity/Tree.java
@@ -29,6 +29,7 @@ import java.util.List;
 @SQLRestriction("is_deleted = false")
 @EntityListeners(AuditingEntityListener.class)
 @Table(name = "TREE")
+@ToString(of = {"id", "title", "description", "createTime", "updateTime"})
 public class Tree {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -72,7 +73,7 @@ public class Tree {
     @Column(name = "BOOK_MARK_COUNT", nullable = false)
     private Integer bookMarkCount = 0;
 
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "tree")
+    @OneToOne(mappedBy = "tree")
     private Memoir memoir;
 
     @NotNull

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepository.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepository.java
@@ -6,5 +6,11 @@ import java.util.List;
 
 public interface TreeQueryRepository {
 
+    /**
+     * memberId로 Tree와 Leaf를 fetchJoin하여 조회
+     * 결과집합이 지나치게 커지는 것을 방지하기 위해 회고록은 지연로딩으로 조회
+     * @param memberId
+     * @return TreeList
+     */
     public List<Tree> findTreeByMemberIdFetch(Long memberId);
 }

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepository.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepository.java
@@ -13,4 +13,5 @@ public interface TreeQueryRepository {
      * @return TreeList
      */
     public List<Tree> findTreeByMemberIdFetch(Long memberId);
+    public List<Tree> findTreeByMemberIdFetch(Long memberId, Long seedId);
 }

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
@@ -28,4 +28,16 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
                 .where(tree.member.id.eq(memberId))
                 .fetch();
     }
+
+    @Override
+    public List<Tree> findTreeByMemberIdFetch(Long memberId, Long seedId) {
+        return queryFactory
+                .selectFrom(tree)
+                .join(tree.leaf, leaf).fetchJoin()
+                .join(tree.book, book).fetchJoin()
+                .join(tree.book.bookCategory, bookCategory).fetchJoin()
+                .where(tree.member.id.eq(memberId).and(tree.seed.id.eq(seedId)))
+                .fetch();
+
+    }
 }

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static io.ggogit.ggogit.domain.book.entity.QBook.book;
+import static io.ggogit.ggogit.domain.book.entity.QBookCategory.bookCategory;
 import static io.ggogit.ggogit.domain.leaf.entity.QLeaf.leaf;
 import static io.ggogit.ggogit.domain.tree.entity.QTree.tree;
 
@@ -21,6 +23,8 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
         return queryFactory
                 .selectFrom(tree)
                 .join(tree.leaf, leaf).fetchJoin()
+                .join(tree.book, book).fetchJoin()
+                .join(tree.book.bookCategory, bookCategory).fetchJoin()
                 .where(tree.member.id.eq(memberId))
                 .fetch();
     }

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/service/TreeService.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/service/TreeService.java
@@ -29,7 +29,8 @@ public interface TreeService  {
     TreeInfoResponse findTreeInfoResponse(Long memberId, Long treeId);
     Page<TreeInfoResponse> findTreeInfoResponseList(Long memberId, Pageable pageable);
 
-//    List<TreeInfoResponse> findTreeInfoResponseList(Long memberId);
+    List<TreeInfoResponse> findTreeInfoResponseList(Long memberId);
+
     //TreeInfoDto 생성
 //    List<TreeInfoResponse> findTreeInfoResponse(Long memberId);
 

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/service/TreeService.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/service/TreeService.java
@@ -30,6 +30,7 @@ public interface TreeService  {
     Page<TreeInfoResponse> findTreeInfoResponseList(Long memberId, Pageable pageable);
 
     List<TreeInfoResponse> findTreeInfoResponseList(Long memberId);
+    List<TreeInfoResponse> findTreeInfoResponseList(Long memberId, Long seedId);
 
     //TreeInfoDto 생성
 //    List<TreeInfoResponse> findTreeInfoResponse(Long memberId);

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/service/TreeServiceImpl.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/service/TreeServiceImpl.java
@@ -18,6 +18,7 @@ import io.ggogit.ggogit.domain.tree.repository.TreeBookRepository;
 import io.ggogit.ggogit.domain.tree.repository.TreeImageRepository;
 import io.ggogit.ggogit.domain.tree.repository.TreeRepository;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -37,6 +38,7 @@ public class TreeServiceImpl implements TreeService {
     private final TreeImageRepository treeImageRepository;
     private final MemberRepository memberRepository;
     private final LeafRepository leafRepository;
+    private final ModelMapper modelMapper;
 
     @Override
     public void register(Tree tree) {
@@ -184,25 +186,25 @@ public class TreeServiceImpl implements TreeService {
         });
     }
 
-//    @Override
-//    public List<TreeInfoResponse> findTreeInfoResponseList(Long memberId) {
-//        List<Tree> treeList = treeRepository.findTreeByMemberIdFetch(memberId);
-//        return treeList.stream()
-//                .map(tree -> {
-//                    tree.get
-//            LocalDateTime lastestLeafTime = null;
-//            Long viewCount = 0L;
-//            Long likeCount = 0L;
-//            Long leafCount = 0L;
-//            for (Leaf leaf : leafList) {
-//                viewCount += leaf.getViewCount();
-//                likeCount += leaf.getLikeCount();
-//                leafCount++;
-//            }
-//            lastestLeafTime = tree.getUpdateTime();
-//            return TreeInfoResponse.of(tree, lastestLeafTime != null ? lastestLeafTime : LocalDateTime.now(), leafCount, likeCount, viewCount);
-//        }).toList();
-//    }
+    @Override
+    public List<TreeInfoResponse> findTreeInfoResponseList(Long memberId) {
+        List<Tree> trees = treeRepository.findTreeByMemberIdFetch(memberId);
 
+        return trees.stream().map(tree -> {
+            LocalDateTime lastestLeafTime = null;
+            Long viewCount = 0L;
+            Long likeCount = 0L;
+            Long leafCount = 0L;
+            List<Leaf> leafs = tree.getLeaf();
+            for (Leaf leaf : leafs) {
+                viewCount += leaf.getViewCount();
+                likeCount += leaf.getLikeCount();
+                leafCount++;
+                if(lastestLeafTime == null || lastestLeafTime.isBefore(leaf.getUpdateTime() != null ? leaf.getUpdateTime() : LocalDateTime.now()))
+                    lastestLeafTime = leaf.getUpdateTime();
+            }
+            return TreeInfoResponse.of(tree, lastestLeafTime != null ? lastestLeafTime : LocalDateTime.now(), leafCount, likeCount, viewCount);
 
+        }).toList();
+    }
 }

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/service/TreeServiceImpl.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/service/TreeServiceImpl.java
@@ -207,4 +207,25 @@ public class TreeServiceImpl implements TreeService {
 
         }).toList();
     }
+    @Override
+    public List<TreeInfoResponse> findTreeInfoResponseList(Long memberId, Long seedId) {
+        List<Tree> trees = treeRepository.findTreeByMemberIdFetch(memberId, seedId);
+
+        return trees.stream().map(tree -> {
+            LocalDateTime lastestLeafTime = null;
+            Long viewCount = 0L;
+            Long likeCount = 0L;
+            Long leafCount = 0L;
+            List<Leaf> leafs = tree.getLeaf();
+            for (Leaf leaf : leafs) {
+                viewCount += leaf.getViewCount();
+                likeCount += leaf.getLikeCount();
+                leafCount++;
+                if(lastestLeafTime == null || lastestLeafTime.isBefore(leaf.getUpdateTime() != null ? leaf.getUpdateTime() : LocalDateTime.now()))
+                    lastestLeafTime = leaf.getUpdateTime();
+            }
+            return TreeInfoResponse.of(tree, lastestLeafTime != null ? lastestLeafTime : LocalDateTime.now(), leafCount, likeCount, viewCount);
+
+        }).toList();
+    }
 }

--- a/backend-2/src/test/java/io/ggogit/ggogit/domain/tree/repository/TreeQueryRepositoryTest.java
+++ b/backend-2/src/test/java/io/ggogit/ggogit/domain/tree/repository/TreeQueryRepositoryTest.java
@@ -1,0 +1,36 @@
+package io.ggogit.ggogit.domain.tree.repository;
+
+import io.ggogit.ggogit.domain.tree.entity.Tree;
+import io.ggogit.ggogit.domain.tree.repository.query.TreeQueryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Description;
+
+import java.util.List;
+
+@SpringBootTest
+public class TreeQueryRepositoryTest {
+
+    @Autowired
+    private TreeQueryRepository treeQueryRepositoryImpl;
+
+        @Test
+        @Description("queryDsl을 이용한 fetchJoin 테스트")
+        public void findTreeByMemberIdFetchTest() {
+            //given
+            List<Tree> treeByMemberIdFetch = treeQueryRepositoryImpl.findTreeByMemberIdFetch(2L);
+
+            // when
+            for (Tree tree : treeByMemberIdFetch) {
+                System.out.println("tree = " + tree.toString());
+                for(int i = 0; i < tree.getLeaf().size(); i++) {
+                    System.out.println("tree.getLeaf().get(i) = " + tree.getLeaf().get(i).toString());
+                }
+            }
+            // then
+
+}
+
+}
+

--- a/backend-2/src/test/java/io/ggogit/ggogit/domain/tree/repository/TreeServiceTest.java
+++ b/backend-2/src/test/java/io/ggogit/ggogit/domain/tree/repository/TreeServiceTest.java
@@ -1,0 +1,31 @@
+package io.ggogit.ggogit.domain.tree.repository;
+
+import io.ggogit.ggogit.api.tree.dto.TreeInfoResponse;
+import io.ggogit.ggogit.domain.tree.service.TreeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+@SpringBootTest
+public class TreeServiceTest {
+
+    @Autowired
+    private TreeService treeService;
+    
+    @Test
+    public void findTreeByMemberIdTest() {
+        //given
+        List<TreeInfoResponse> treeDtos = treeService.findTreeInfoResponseList(1L);
+
+        // when
+        for(TreeInfoResponse treeDto : treeDtos) {
+            System.out.println("treeDto = " + treeDto.toString());
+        }
+        
+        // then
+     }
+    
+        
+}

--- a/frontend-2/components/background/BgTreeBookCovers.vue
+++ b/frontend-2/components/background/BgTreeBookCovers.vue
@@ -1,22 +1,23 @@
 <script setup>
-
-const { data } = defineProps(['data']);
-/*
-treeId
-coverImageName
-length
- */
-
+const props = defineProps({
+  treeInfoList: {
+    type: Array,
+    required: true,
+  },
+});
+const treeInfoList = ref(props.treeInfoList);
+watchEffect(() => {
+  treeInfoList.value = props.treeInfoList;
+});
 </script>
 
 <template>
   <div class="tree-book-bg">
     <ul class="tree-book-bg__list">
       <li
-        class="mid__item"
-        v-for="(tree, index) in data"
+        :class="`mid__item ${index}`"
+        v-for="(tree, index) in treeInfoList"
         :key="index"
-        :class="index"
       >
         <a :href="`/tree/detail/${tree.treeId}`">
           <img
@@ -26,7 +27,7 @@ length
           />
         </a>
       </li>
-      <li v-if="data.length === 1" class="mid__item 1">
+      <li v-if="treeInfoList.length === 1" class="mid__item 1">
         <a href="/seed/index">
           <img
             class="mid__img"
@@ -35,7 +36,7 @@ length
           />
         </a>
       </li>
-      <li v-if="data.length <= 2" class="mid__item 2">
+      <li v-if="treeInfoList.length <= 2" class="mid__item 2">
         <a href="/seed/index">
           <img
             class="mid__img"
@@ -45,10 +46,9 @@ length
         </a>
       </li>
       <li
-        class="mid__item"
-        v-for="(tree, index) in data"
+        :class="`mid__item ${index}`"
+        v-for="(tree, index) in treeInfoList"
         :key="index"
-        :class="index"
       >
         <a :href="`/tree/detail/${tree.treeId}`">
           <img
@@ -58,7 +58,7 @@ length
           />
         </a>
       </li>
-      <li v-if="data.length === 1" class="mid__item 1">
+      <li v-if="treeInfoList.length === 1" class="mid__item 1">
         <a href="/seed/index">
           <img
             class="mid__img"
@@ -67,7 +67,7 @@ length
           />
         </a>
       </li>
-      <li v-if="data.length <= 2" class="mid__item 2">
+      <li v-if="treeInfoList.length <= 2" class="mid__item 2">
         <a href="/seed/index">
           <img
             class="mid__img"
@@ -77,10 +77,9 @@ length
         </a>
       </li>
       <li
-        class="mid__item"
-        v-for="(tree, index) in data"
+        :class="`mid__item ${index}`"
+        v-for="(tree, index) in treeInfoList"
         :key="index"
-        :class="index"
       >
         <a :href="`/tree/detail/${tree.treeId}`">
           <img
@@ -90,7 +89,7 @@ length
           />
         </a>
       </li>
-      <li v-if="data.length === 1" class="mid__item 1">
+      <li v-if="treeInfoList.length === 1" class="mid__item 1">
         <a href="/seed/index">
           <img
             class="mid__img"
@@ -99,7 +98,7 @@ length
           />
         </a>
       </li>
-      <li v-if="data.length <= 2" class="mid__item 2">
+      <li v-if="treeInfoList.length <= 2" class="mid__item 2">
         <a href="/seed/index">
           <img
             class="mid__img"

--- a/frontend-2/components/button/BtnShortGreen.vue
+++ b/frontend-2/components/button/BtnShortGreen.vue
@@ -1,10 +1,8 @@
-<script setup lang="ts">
-
-const props = defineProps<{
-  text: String;
-  type: String;
-}>();
-
+<script setup>
+const props = defineProps({
+  text: "",
+  type: "",
+});
 </script>
 
 <template>

--- a/frontend-2/components/card/CardProgressBar.vue
+++ b/frontend-2/components/card/CardProgressBar.vue
@@ -8,7 +8,7 @@ import { defineProps } from "vue";
 
 const props = defineProps({
   progress: 0,
-  readPage: 0,
+  readingPage: 0,
   totalPage: 0,
 });
 
@@ -17,7 +17,7 @@ function progressStyle(progress) {
 }
 
 const progress = props.progress;
-const readPage = props.readPage;
+const readPage = props.readingPage;
 const fullPage = props.totalPage;
 </script>
 
@@ -39,7 +39,7 @@ const fullPage = props.totalPage;
       </div>
       <div class="card-reading-progress__page-num">
         <span class="card-progress-page__current">{{ readPage }}</span>
-        <span class="card-progress-page__sep">/</span>
+        <span class="card-progress-page__sep"> / </span>
         <span class="card-progress-page__total"> {{ fullPage }} </span>
       </div>
     </div>

--- a/frontend-2/components/card/CardProgressBar.vue
+++ b/frontend-2/components/card/CardProgressBar.vue
@@ -4,15 +4,21 @@
 //   readPage: data.readingPage,
 //   fullPage: data.bookTotalPage,
 // };
-import {defineProps} from 'vue';
+import { defineProps } from "vue";
 
-const {data} = defineProps(['data']);
+const props = defineProps({
+  progress: 0,
+  readPage: 0,
+  totalPage: 0,
+});
 
 function progressStyle(progress) {
   return `width: ${progress}%;`;
 }
 
-
+const progress = props.progress;
+const readPage = props.readPage;
+const fullPage = props.totalPage;
 </script>
 
 <template>
@@ -20,18 +26,21 @@ function progressStyle(progress) {
     <div class="card-reading-progress__title">
       <h2>독서 진행률</h2>
       <div>
-        <span class="card-reading-progress__num">{{ data.progress }}</span>
+        <span class="card-reading-progress__num">{{ progress }}</span>
         <span class="card-reading-progress__sep">%</span>
       </div>
     </div>
     <div class="card-reading-progress-content">
       <div class="card-reading-progress__bar-container">
-        <div class="card-reading-progress__bar" :style="progressStyle(data.progress)"></div>
+        <div
+          class="card-reading-progress__bar"
+          :style="progressStyle(progress)"
+        ></div>
       </div>
       <div class="card-reading-progress__page-num">
-        <span class="card-progress-page__current">{{ data.readPage }}</span>
+        <span class="card-progress-page__current">{{ readPage }}</span>
         <span class="card-progress-page__sep">/</span>
-        <span class="card-progress-page__total"> {{ data.fullPage }} </span>
+        <span class="card-progress-page__total"> {{ fullPage }} </span>
       </div>
     </div>
   </div>

--- a/frontend-2/components/card/CardReactNumbers.vue
+++ b/frontend-2/components/card/CardReactNumbers.vue
@@ -1,32 +1,36 @@
-<script setup lang="ts">
-// const cardReactNumbersProps = {
-//   leaf: data.treeLeafCnt,
-//   like: data.treeLikeCnt,
-//   view: data.treeViewCnt,
-// };
-import { defineProps } from 'vue';
+<script setup>
+import { defineProps } from "vue";
 
-const {data} = defineProps(['data']);
+const props = defineProps({
+  leaf: 0,
+  like: 0,
+  view: 0,
+});
 
 function modifyCount(count) {
-  return 999 < count ? '999+' : String(count);
+  return 999 < count ? "999+" : String(count);
 }
-
 </script>
 
 <template>
   <div class="card-reading-progress-status__list">
     <p class="card-reading-progress-status__leaf">
       리프
-      <span class="card-reading-progress-status__num">{{ modifyCount(data.leaf) }}</span>
+      <span class="card-reading-progress-status__num">{{
+        modifyCount(props.leaf)
+      }}</span>
     </p>
     <p class="card-reading-progress-status__like">
       좋아요
-      <span class="card-reading-progress-status__num">{{ modifyCount(data.like) }}</span>
+      <span class="card-reading-progress-status__num">{{
+        modifyCount(props.like)
+      }}</span>
     </p>
     <p class="card-reading-progress-status__views">
       조회수
-      <span class="card-reading-progress-status__num">{{ modifyCount(data.view) }}</span>
+      <span class="card-reading-progress-status__num">{{
+        modifyCount(props.view)
+      }}</span>
     </p>
   </div>
 </template>

--- a/frontend-2/components/card/CardTreeDetails.vue
+++ b/frontend-2/components/card/CardTreeDetails.vue
@@ -1,40 +1,16 @@
-<script setup lang="ts">
-
+<script setup>
 import { computed } from "vue";
 
-interface CardTreeDetailsProps {
-    treeId: string;
-    coverImageName: string;
-    bookCategory: string;
-    bookTitle: string;
-    treeTitle: string
-    bookPublishedYear: string;
-    bookComplete: boolean;
-    bookAuthor: string;
-    bookTranslator: string;
-    bookPublisher: string;
-    leafCreatedAt: string;
-}
+const props = defineProps({
+  tree: {
+    type: Object,
+    required: true,
+  },
+});
 
-const data: CardTreeDetailsProps  = {
-    treeId: '',
-    coverImageName: '',
-    bookCategory: '도서',
-    bookTitle: '운명이란 무엇인가?',
-    bookComplete: true,
-    treeTitle: '운명이란 무엇인가?',
-    bookPublishedYear: '2024',
-    bookAuthor: '유시민',
-    bookTranslator: '유시민',
-    bookPublisher: '생각의 길',
-    leafCreatedAt: '2024-07-15'
-};
+const tree = ref(props.tree);
 
-const detailLink = computed(() => `/tree/detail/${data.treeId}`);
-const props = defineProps<{
-    data: CardTreeProps;
-}>();
-
+const detailLink = computed(() => `/tree/detail/${tree.treeId}`);
 </script>
 
 <template>
@@ -42,33 +18,53 @@ const props = defineProps<{
 
   <div class="card-tree-details">
     <a class="card-tree-detail" :href="detailLink">
-
       <div class="card-tree__img-frame">
-        <img v-if="coverImageName" class="card-tree__book-cover" alt="treeCover" :src="data.coverImageName"/>
-        <img v-else class="card-tree__book-cover" src="/public/svg/tree-icon--white.svg" alt="treeCover"/>
+        <img
+          v-if="tree.coverImageName"
+          class="card-tree__book-cover"
+          alt="treeCover"
+          :src="tree.coverImageName"
+        />
+        <img
+          v-else
+          class="card-tree__book-cover"
+          src="/public/svg/tree-icon--white.svg"
+          alt="treeCover"
+        />
       </div>
 
       <div class="card-tree-detail__box">
         <!--반복문으로 넣어야 할듯..-->
-          <div class="card-tree-detail__tags">
-            <span class="card-tree-detail__tag">{{ data.bookCategory }}</span>
-          </div>
+        <div class="card-tree-detail__tags">
+          <span class="card-tree-detail__tag">{{ tree.bookCategory }}</span>
+        </div>
         <!---->
         <div class="card-tree-detail__slot">
-          <p class="card-tree-detail__name">{{ data.bookTitle }}</p>
-          <div v-if="data.bookComplete" class="card-tree-detail__complete-icon" ></div>
+          <p class="card-tree-detail__name">{{ tree.bookTitle }}</p>
+          <div
+            v-if="tree.bookComplete"
+            class="card-tree-detail__complete-icon"
+          ></div>
         </div>
-        <p class="card-tree-detail__explanation">{{data.treeTitle}}</p>
+        <p class="card-tree-detail__explanation">{{ tree.treeTitle }}</p>
         <div class="card-tree-detail__info">
-          <span class="card-tree-detail__info">{{ data.bookPublishedYear }}</span>
+          <span class="card-tree-detail__info">{{
+            tree.bookPublishedYear
+          }}</span>
           <span class="card-tree-detail__info"> / </span>
-          <span class="card-tree-detail__info">{{ data.bookAuthor }}</span>
+          <span class="card-tree-detail__info">{{ tree.bookAuthor }}</span>
           <span class="card-tree-detail__info"> / </span>
-          <span v-if="data.bookTranslator" class="card-tree-detail__info">{{ data.bookTranslator }}</span>
-          <span class="card-tree-detail__info" v-if="data.bookTranslator">/</span>
-          <span class="card-tree-detail__info">{{ data.bookPublisher }}</span>
+          <span v-if="tree.bookTranslator" class="card-tree-detail__info">{{
+            data.bookTranslator
+          }}</span>
+          <span class="card-tree-detail__info" v-if="tree.bookTranslator"
+            >/</span
+          >
+          <span class="card-tree-detail__info">{{ tree.bookPublisher }}</span>
         </div>
-        <span class="card-tree-detail__info-created-date">{{ data.leafCreatedAt }}</span>
+        <span class="card-tree-detail__info-created-date">{{
+          tree.leafCreatedAt
+        }}</span>
       </div>
     </a>
   </div>
@@ -86,7 +82,7 @@ const props = defineProps<{
   width: 100%;
   display: flex;
   flex-direction: row;
-  gap:10px
+  gap: 10px;
 }
 
 .card-tree__book-cover {
@@ -115,7 +111,7 @@ const props = defineProps<{
   font-size: 10px;
   margin-right: 2px;
 }
-.card-tree-detail__slot{
+.card-tree-detail__slot {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -127,12 +123,12 @@ const props = defineProps<{
   align-items: center;
   justify-content: space-between;
 }
-.card-tree-detail__complete-icon{
+.card-tree-detail__complete-icon {
   display: inline-flex;
   width: 20px;
   height: 20px;
   background-color: var(--main1);
-  mask-image:url("/svg/card-tree-details-complete.svg");
+  mask-image: url("/svg/card-tree-details-complete.svg");
   mask-size: contain;
   mask-repeat: no-repeat;
   mask-position: center;

--- a/frontend-2/components/filter/FilterTreeList.vue
+++ b/frontend-2/components/filter/FilterTreeList.vue
@@ -5,6 +5,9 @@ const props = defineProps({
     required: true,
   },
 });
+
+const emit = defineEmits(["seedFilter"]);
+
 const seedList = ref(props.seedList);
 watchEffect(() => {
   seedList.value = props.seedList;
@@ -30,6 +33,7 @@ watchEffect(() => {
         name="seedList"
         :key="index + 1"
         :label="`${seed.korName}`"
+        @click="$emit('seedFilter', seed.id)"
       />
     </label>
   </div>

--- a/frontend-2/components/filter/FilterTreeList.vue
+++ b/frontend-2/components/filter/FilterTreeList.vue
@@ -1,15 +1,36 @@
-<script setup lang="ts">
-
+<script setup>
+const props = defineProps({
+  seedList: {
+    type: Array,
+    required: true,
+  },
+});
+const seedList = ref(props.seedList);
+watchEffect(() => {
+  seedList.value = props.seedList;
+});
 </script>
 
 <template>
   <!-- (seedList) -->
-  <div class="filter-tree-list" >
+  <div class="filter-tree-list">
     <label>
-      <input class="filter-tree-list-img seedFilterEvent" type="radio" name="treeList" data-id="0" label="" checked/>
+      <input
+        class="filter-tree-list-img seedFilterEvent"
+        type="radio"
+        name="seedList"
+        key="0"
+        checked
+      />
     </label>
-    <label>
-      <input class="filter-tree-list-btn seedFilterEvent" type="radio" name="treeList" data-id="${seed.id}"/>
+    <label v-for="(seed, index) in seedList">
+      <input
+        class="filter-tree-list-btn seedFilterEvent"
+        type="radio"
+        name="seedList"
+        :key="index + 1"
+        :label="`${seed.korName}`"
+      />
     </label>
   </div>
 </template>
@@ -21,7 +42,7 @@
   gap: 5px;
   flex-direction: row;
 }
-.filter-tree-list-img{
+.filter-tree-list-img {
   background-image: url("/svg/sort.svg");
   background-size: 50%;
   background-position: center;

--- a/frontend-2/components/header/HeaderSearchLink.vue
+++ b/frontend-2/components/header/HeaderSearchLink.vue
@@ -1,59 +1,61 @@
-<script setup>
-
-</script>
+<script setup></script>
 
 <template>
-    <!-- header-search-link -->
-    <div class="header-search-link">
-        <router-link class="header-search-link__link" to="/tree/book/select">
-            <div class="header-search-link__input-box">
-                <p class="header-search-link__placeholder">나의 트리 검색</p>
-                <img class="header-search-link__icon" src="/svg/lens.svg" alt="lens.svg"/>
-            </div>
-        </router-link>
-    </div>
+  <!-- header-search-link -->
+  <div class="header-search-link">
+    <router-link class="header-search-link__link" to="/tree/book/search">
+      <div class="header-search-link__input-box">
+        <p class="header-search-link__placeholder">나의 트리 검색</p>
+        <img
+          class="header-search-link__icon"
+          src="/svg/lens.svg"
+          alt="lens.svg"
+        />
+      </div>
+    </router-link>
+  </div>
 </template>
 
 <style scoped>
 .header-search-link {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    align-self: stretch;
-    position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  align-self: stretch;
+  position: relative;
 }
 
 .header-search-link__link {
-    align-self: stretch;
+  align-self: stretch;
 }
 
 .header-search-link__input-box {
-    background: var(--main2, #e5eddb);
-    border-radius: 100px;
-    padding: 0 16px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    align-self: stretch;
-    height: 40px;
-    position: relative;
+  background: var(--main2, #e5eddb);
+  border-radius: 100px;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  align-self: stretch;
+  height: 40px;
+  position: relative;
 }
 
 .header-search-link__placeholder {
-    color: var(--text-sub);
-    font-size: 14px;
-    line-height: var(--line-height-main);
-    letter-spacing: var(--letter-spacing-main);
-    font-weight: var(--medium);
-    position: relative;
-    transform: translateY(8%);
+  color: var(--text-sub);
+  font-size: 14px;
+  line-height: var(--line-height-main);
+  letter-spacing: var(--letter-spacing-main);
+  font-weight: var(--medium);
+  position: relative;
+  transform: translateY(8%);
 }
 
 .header-search-link__icon {
-    flex-shrink: 0;
-    width: 18px;
-    height: 18px;
-    position: relative;
-    overflow: visible;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  position: relative;
+  overflow: visible;
 }
 </style>

--- a/frontend-2/components/text/RecentTreeInfo.vue
+++ b/frontend-2/components/text/RecentTreeInfo.vue
@@ -1,51 +1,131 @@
 <script setup>
 const props = defineProps({
-    tree: {
-        type: Object,
-        required: true,
-        default: () => ({
-            title: '나의 첫번째 트리',
-            bookCategory: '시/에세이',
-            bookTitle: '무정형의 삶',
-            bookAuthor: '김민철',
-            bookPublisher: '위즈덤 하우스',
-            createdAt: new Date()
-        })
-    }
-})
+  tree: {
+    type: Object,
+    required: true,
+    default: () => ({
+      title: "나의 첫번째 트리",
+      bookCategory: "시/에세이",
+      bookTitle: "무정형의 삶",
+      bookAuthor: "김민철",
+      bookPublisher: "위즈덤 하우스",
+      createdAt: new Date(),
+    }),
+  },
+});
 
 const formatDate = (date) => {
-    if (!(date instanceof Date)) {
-        date = new Date(date)
-    }
-    return date.toISOString().split('T')[0]
-}
+  if (!(date instanceof Date)) {
+    date = new Date(date);
+  }
+  return date.toISOString().split("T")[0];
+};
 </script>
 
 <template>
-    <!-- recent-tree-info(tree) -->
-    <div class="textbox-recent-tree-info">
-        <div class="textbox-recent-tree-info__a">
-            <h2 class="textbox-recent-tree-info__tree-title">
-                {{ tree.title }}
-            </h2>
-            <div class="textbox-recent-tree-info__tag tag">
-                {{ tree.bookCategory }}
-            </div>
-            <p class="textbox-recent-tree-info__book-title">
-                {{ tree.bookTitle }}
-            </p>
-            <div class="textbox-recent-tree-info__items">
-                <p class="textbox-recent-tree-info__author">{{ tree.bookAuthor }}</p>
-                <p class="textbox-recent-tree-info__publisher">{{ tree.bookPublisher }}</p>
-            </div>
-            <p class="textbox-recent-tree-info__date">
-                {{ formatDate(tree.createdAt) }}
-            </p>
-        </div>
+  <!-- recent-tree-info(tree) -->
+  <div class="textbox-recent-tree-info">
+    <div class="textbox-recent-tree-info__a">
+      <h2 class="textbox-recent-tree-info__tree-title">
+        {{ tree.title }}
+      </h2>
+      <div class="textbox-recent-tree-info__tag tag">
+        {{ tree.bookCategory }}
+      </div>
+      <p class="textbox-recent-tree-info__book-title">
+        {{ tree.bookTitle }}
+      </p>
+      <div class="textbox-recent-tree-info__items">
+        <p class="textbox-recent-tree-info__author">{{ tree.bookAuthor }}</p>
+        <p class="textbox-recent-tree-info__publisher">
+          {{ tree.bookPublisher }}
+        </p>
+      </div>
+      <p class="textbox-recent-tree-info__date">
+        {{ formatDate(tree.createdAt) }}
+      </p>
     </div>
+  </div>
 </template>
 
 <style scoped>
+/*  ==========================================
+    FRAGMENT: 최근 트리 정보
+    ========================================== */
+.textbox-recent-tree-info__a {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--text-sub);
+  text-decoration: none;
+}
 
+.tag {
+  font-size: 10px;
+  color: var(--white);
+  background-color: var(--main1);
+  border-radius: 4px;
+  text-align: center;
+  padding: 2px 8px;
+  border: none;
+  line-height: var(--line-height-main);
+}
+
+.textbox-recent-tree-info__tag {
+  order: 0;
+  margin-bottom: 4px;
+}
+
+.textbox-recent-tree-info__tree-title {
+  order: 1;
+  margin-bottom: 4px;
+  font-size: 18px;
+  font-weight: var(--semi-bold);
+  color: var(--main1);
+  line-height: var(--line-height-main);
+  letter-spacing: var(--letter-spacing-main);
+}
+
+.textbox-recent-tree-info__book-title {
+  order: 2;
+  font-size: 16px;
+  line-height: var(--line-height-main);
+  margin-bottom: 4px;
+}
+
+.textbox-recent-tree-info__items {
+  color: var(--text-sub);
+  display: flex;
+  order: 3;
+}
+
+.textbox-recent-tree-info__author {
+  line-height: var(--line-height-main);
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.textbox-recent-tree-info__author::after {
+  content: " · ";
+  font-size: 14px;
+  padding-left: 3px;
+  padding-right: 3px;
+}
+
+.textbox-recent-tree-info__publisher {
+  line-height: var(--line-height-main);
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+.textbox-recent-tree-info__date {
+  order: 4;
+  line-height: var(--line-height-main);
+  font-size: 14px;
+  font-weight: var(--semi-bold);
+}
+
+.book-tree-explanation-item {
+  transition: all, 0.3s, linear;
+}
 </style>

--- a/frontend-2/pages/home/index.vue
+++ b/frontend-2/pages/home/index.vue
@@ -9,30 +9,24 @@ import { onBeforeMount, onMounted, reactive } from "vue";
 const config = useRuntimeConfig();
 const treeInfoList = ref([]);
 const seedList = ref([]);
+let observer = null;
 
 //TODO: JWT토큰 있다면 전송하게끔 로직 수정 필요
-const FetchData = async () => {
-  const {
-    data: seedData,
-    error: seedError,
-    status: seedStatus,
-  } = await useFetch("seeds", {
+const fetchData = async () => {
+  const { data: seedData, status: seedStatus } = await useFetch("seeds", {
     baseURL: `${config.public.apiBase}`,
     method: "GET",
-    initialCache: true,
   });
-  const {
-    data: treeData,
-    error: treeError,
-    status: treeStatus,
-  } = await useFetch("trees/tree-home", {
-    baseURL: `${config.public.apiBase}`,
-    method: "GET",
-    params: {
-      mid: useRoute().query.mid,
-    },
-    initialCache: true,
-  });
+  const { data: treeData, status: treeStatus } = await useFetch(
+    "trees/tree-home",
+    {
+      baseURL: `${config.public.apiBase}`,
+      method: "GET",
+      params: {
+        mid: useRoute().query.mid,
+      },
+    }
+  );
 
   watchEffect(() => {
     if (treeStatus.value === "success" && treeData.value) {
@@ -49,12 +43,9 @@ const FetchData = async () => {
   });
 };
 
-FetchData();
-
 //-------------------LifeCycle-------------------
 onMounted(async () => {
-  await nextTick();
-
+  await fetchData();
   const carouselList = document.querySelector(".tree-book-bg__list");
   // carousel item 너비
   // const width = document.querySelector(".mid__item").clientWidth;
@@ -67,8 +58,8 @@ onMounted(async () => {
 
   if (!import.meta.env.SSR) {
     // ----- 한 가운데 item 찾아내기 위한 IntersectionObserver코드 --------
-    const container = carouselList.querySelector(".tree-book-bg");
-    const observer = new IntersectionObserver(
+    // const container = carouselList.querySelector(".tree-book-bg");
+    observer = new IntersectionObserver(
       (entries) => {
         let selectedElement = null;
 
@@ -84,12 +75,60 @@ onMounted(async () => {
           bookExRemoveNone(selectedElement);
         }
       },
-      { root: container, threshold: 0.6 }
+      { threshold: 0.3 }
     );
 
     carouselItems.forEach((item) => {
       observer.observe(item);
     });
+
+    //--------------------------------가운데 트리 확대 로직--------------------------------
+    const bookExRemoveNone = (selectedElement) => {
+      const id = selectedElement.classList[1];
+
+      carouselList.querySelectorAll(".mid__item").forEach((item) => {
+        if (item === selectedElement) {
+          item.querySelector(".mid__img").classList.add("center__img");
+        } else {
+          item.querySelector(".mid__img").classList.remove("center__img");
+        }
+      });
+
+      document
+        .querySelectorAll(".textbox-recent-tree-info__frame")
+        .forEach((item) => {
+          if (item.classList.contains(id)) {
+            item.classList.remove("none");
+          } else {
+            item.classList.add("none");
+          }
+        });
+
+      document
+        .querySelectorAll(".book-tree-explanation-item")
+        .forEach((item) => {
+          if (item.classList.contains(id)) {
+            item.classList.remove("none");
+          } else {
+            item.classList.add("none");
+          }
+        });
+    };
+
+    const calcMidTree = () => {
+      let ids = [];
+      let ret = null;
+      carouselList.querySelectorAll(".selected").forEach((item) => {
+        ids.push(item.classList[1]);
+      });
+      const midId = String(ids[1]);
+      carouselList.querySelectorAll(".selected").forEach((item) => {
+        if (item.classList[1] === midId) {
+          ret = item;
+        }
+      });
+      return ret;
+    };
   }
 
   //-----------------------------------carousel 이동 로직-----------------------------------
@@ -152,7 +191,7 @@ onMounted(async () => {
 
       // 기본 동작 방지 (특히 모바일에서의 스크롤)
       if (e.type.includes("touch")) {
-        e.preventDefault(); // 기본 터치 스크롤 동작을 방지
+        // e.preventDefault(); // 기본 터치 스크롤 동작을 방지
       }
 
       // 오른쪽으로 최대 이동한 경우
@@ -215,51 +254,7 @@ onMounted(async () => {
       carouselList.style.transform = `translateX(${currentTranslateX}px)`;
     }
   };
-  //--------------------------------가운데 트리 확대 로직--------------------------------
-  const bookExRemoveNone = (selectedElement) => {
-    const id = selectedElement.classList[1];
 
-    carouselList.querySelectorAll(".mid__item").forEach((item) => {
-      if (item === selectedElement) {
-        item.querySelector(".mid__img").classList.add("center__img");
-      } else {
-        item.querySelector(".mid__img").classList.remove("center__img");
-      }
-    });
-
-    document
-      .querySelectorAll(".textbox-recent-tree-info__frame")
-      .forEach((item) => {
-        if (item.classList.contains(id)) {
-          item.classList.remove("none");
-        } else {
-          item.classList.add("none");
-        }
-      });
-
-    document.querySelectorAll(".book-tree-explanation-item").forEach((item) => {
-      if (item.classList.contains(id)) {
-        item.classList.remove("none");
-      } else {
-        item.classList.add("none");
-      }
-    });
-  };
-
-  const calcMidTree = () => {
-    let ids = [];
-    let ret = null;
-    carouselList.querySelectorAll(".selected").forEach((item) => {
-      ids.push(item.classList[1]);
-    });
-    const midId = String(ids[1]);
-    carouselList.querySelectorAll(".selected").forEach((item) => {
-      if (item.classList[1] === midId) {
-        ret = item;
-      }
-    });
-    return ret;
-  };
   //---------------------eventListener 등록---------------------
   //쓰로틀링 적용
   const throttledDragging = _.throttle((e) => {
@@ -285,6 +280,7 @@ onMounted(async () => {
   window.addEventListener("touchmove", throttledDragging, { passive: false });
   window.addEventListener("touchend", (e) => dragEnd(e));
 });
+
 //---------------------------onMounted 끝-----------------------------------
 </script>
 
@@ -318,10 +314,9 @@ onMounted(async () => {
           <h3 class="none">트리 약식 정보</h3>
           <ul>
             <li
-              class="none textbox-recent-tree-info__frame"
               v-for="(tree, index) in treeInfoList"
+              :class="`textbox-recent-tree-info__frame ${index} none`"
               :key="index"
-              :class="index"
             >
               <TextRecentTreeInfo :tree="tree" />
             </li>
@@ -332,10 +327,11 @@ onMounted(async () => {
           <h3 class="none">트리 설명</h3>
           <ul class="book-tree-explanation-list">
             <li
-              class="book-tree-explanation-item none"
               v-for="(tree, index) in treeInfoList"
+              :class="`book-tree-explanation-item
+              ${index}
+              none`"
               :key="index"
-              :class="index"
             >
               <TextRecentTreeEx :text="tree.description" />
               <section class="card-progress-home-container">
@@ -351,7 +347,7 @@ onMounted(async () => {
                         : 0
                     "
                     :readingPage="tree.readingPage"
-                    :totalPage="tree.totalPage"
+                    :totalPage="tree.bookTotalPage"
                   />
                 </div>
                 <CardReactNumbers

--- a/frontend-2/pages/home/index.vue
+++ b/frontend-2/pages/home/index.vue
@@ -4,21 +4,57 @@ import "@toast-ui/editor/dist/toastui-editor.css";
 
 import { onBeforeMount, onMounted, reactive } from "vue";
 
-//-------------------------------변수 선언--------------------------------
-const treeInfoList = reactive([]);
-const seedList = reactive([]);
+//-------------------변수 선언--------------------
+
+const config = useRuntimeConfig();
+const treeInfoList = ref([]);
+const seedList = ref([]);
 
 //TODO: JWT토큰 있다면 전송하게끔 로직 수정 필요
-onBeforeMount(async () => {
-  const { data, error, referch } = await useFetch("trees", {
-    baseURL: import.meta.env.VITE_API_BASE_URL,
+const FetchData = async () => {
+  const {
+    data: seedData,
+    error: seedError,
+    status: seedStatus,
+  } = await useFetch("seeds", {
+    baseURL: `${config.public.apiBase}`,
     method: "GET",
+    initialCache: true,
+  });
+  const {
+    data: treeData,
+    error: treeError,
+    status: treeStatus,
+  } = await useFetch("trees/tree-home", {
+    baseURL: `${config.public.apiBase}`,
+    method: "GET",
+    params: {
+      mid: useRoute().query.mid,
+    },
+    initialCache: true,
   });
 
-  await treeInfoList.push(...data.data);
-});
+  watchEffect(() => {
+    if (treeStatus.value === "success" && treeData.value) {
+      treeInfoList.value = [...treeData.value.treeInfoResponseList];
+    } else {
+      console.log("treeData.value is null");
+    }
 
-onMounted(() => {
+    if (seedStatus.value === "success" && seedData.value) {
+      seedList.value = [...seedData.value.items];
+    } else {
+      console.log("seedData.value is null");
+    }
+  });
+};
+
+FetchData();
+
+//-------------------LifeCycle-------------------
+onMounted(async () => {
+  await nextTick();
+
   const carouselList = document.querySelector(".tree-book-bg__list");
   // carousel item 너비
   // const width = document.querySelector(".mid__item").clientWidth;
@@ -28,30 +64,33 @@ onMounted(() => {
   const carouselItems = document.querySelectorAll(".mid__item");
   // carousel item 전체 갯수
   const carouselItemCount = carouselItems.length / 3;
-  // --------------- 한 가운데 item 찾아내기 위한 IntersectionObserver코드 --------------
-  const container = carouselList.querySelector(".tree-book-bg");
-  const observer = new IntersectionObserver(
-    (entries) => {
-      let selectedElement = null;
 
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add("selected");
-        } else {
-          entry.target.classList.remove("selected");
+  if (!import.meta.env.SSR) {
+    // ----- 한 가운데 item 찾아내기 위한 IntersectionObserver코드 --------
+    const container = carouselList.querySelector(".tree-book-bg");
+    const observer = new IntersectionObserver(
+      (entries) => {
+        let selectedElement = null;
+
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("selected");
+          } else {
+            entry.target.classList.remove("selected");
+          }
+        });
+        selectedElement = calcMidTree();
+        if (selectedElement) {
+          bookExRemoveNone(selectedElement);
         }
-      });
-      selectedElement = calcMidTree();
-      if (selectedElement) {
-        bookExRemoveNone(selectedElement);
-      }
-    },
-    { root: container, threshold: 0.6 }
-  );
+      },
+      { root: container, threshold: 0.6 }
+    );
 
-  carouselItems.forEach((item) => {
-    observer.observe(item);
-  });
+    carouselItems.forEach((item) => {
+      observer.observe(item);
+    });
+  }
 
   //-----------------------------------carousel 이동 로직-----------------------------------
 
@@ -231,7 +270,7 @@ onMounted(() => {
 
   // PC
   carouselList.addEventListener("mousedown", (e) => dragStart(e, e.clientX));
-  // window.addEventListener("mousemove", (e) => dragging(e, e.clientX));
+  window.addEventListener("mousemove", (e) => dragging(e, e.clientX));
   window.addEventListener("mousemove", throttledDragging, { passive: false });
   window.addEventListener("mouseup", (e) => dragEnd(e));
 
@@ -239,9 +278,9 @@ onMounted(() => {
   carouselList.addEventListener("touchstart", (e) =>
     dragStart(e, e.targetTouches[0].clientX)
   );
-  // window.addEventListener("touchmove", (e) =>
-  //   dragging(e, e.targetTouches[0].clientX)
-  // );
+  window.addEventListener("touchmove", (e) =>
+    dragging(e, e.targetTouches[0].clientX)
+  );
 
   window.addEventListener("touchmove", throttledDragging, { passive: false });
   window.addEventListener("touchend", (e) => dragEnd(e));
@@ -250,130 +289,124 @@ onMounted(() => {
 </script>
 
 <template>
-  <body>
-    <header>
-      <h1 class="none">나의 트리</h1>
-      <section class="header-search-container">
-        <h2 class="none">나의 트리 검색 링크</h2>
-        <HeaderSearchLink />
-      </section>
-    </header>
+  <header>
+    <h1 class="none">나의 트리</h1>
+    <section class="header-search-container">
+      <h2 class="none">나의 트리 검색 링크</h2>
+      <HeaderSearchLink />
+    </section>
+  </header>
 
-    <main>
-      <section class="my-tree-container">
-        <h2 class="none">나의 트리 정보</h2>
-        <section class="my-tree-title-container">
-          <h3>
-            <TextMainTitle :data="{ title: '나의 트리', size: 28 }" />
-          </h3>
+  <main>
+    <section class="my-tree-container">
+      <h2 class="none">나의 트리 정보</h2>
+      <section class="my-tree-title-container">
+        <h3>
+          <TextMainTitle :data="{ title: '나의 트리', size: 28 }" />
+        </h3>
+      </section>
+
+      <section class="book-tree-info-container">
+        <h3 class="none">최근 트리 이미지 캐러셀</h3>
+        <section class="book-img-container">
+          <div>
+            <BackgroundBgTreeBookCovers :treeInfoList="treeInfoList" />
+          </div>
         </section>
 
-        <section class="book-tree-info-container">
-          <h3 class="none">최근 트리 이미지 캐러셀</h3>
-          <section class="book-img-container">
-            <div>
-              <BgTreeBookCovers :trees="treeInfoList" />
-            </div>
-          </section>
+        <section>
+          <h3 class="none">트리 약식 정보</h3>
+          <ul>
+            <li
+              class="none textbox-recent-tree-info__frame"
+              v-for="(tree, index) in treeInfoList"
+              :key="index"
+              :class="index"
+            >
+              <TextRecentTreeInfo :tree="tree" />
+            </li>
+          </ul>
+        </section>
 
-          <section>
-            <h3 class="none">트리 약식 정보</h3>
-            <ul>
-              <li
-                class="none textbox-recent-tree-info__frame"
-                v-for="(tree, index) in treeInfoList"
-                :key="index"
-                :class="index"
-              >
-                <RecentTreeInfo :tree="tree" />
-              </li>
-            </ul>
-          </section>
-
-          <section class="book-tree-explanation-container">
-            <h3 class="none">트리 설명</h3>
-            <ul class="book-tree-explanation-list">
-              <li
-                class="book-tree-explanation-item none"
-                v-for="tree in treeInfoList"
-                :key="index"
-                :class="index"
-              >
-                <RecentTreeEx :text="tree.description" />
-                <section
-                  class="card-progress-home-container"
-                  :readingPage="tree.readingPage"
-                  :totalPage="tree.bookTotalPage"
+        <section class="book-tree-explanation-container">
+          <h3 class="none">트리 설명</h3>
+          <ul class="book-tree-explanation-list">
+            <li
+              class="book-tree-explanation-item none"
+              v-for="(tree, index) in treeInfoList"
+              :key="index"
+              :class="index"
+            >
+              <TextRecentTreeEx :text="tree.description" />
+              <section class="card-progress-home-container">
+                <h4 class="none">트리 진행률</h4>
+                <div v-if="tree.seedId === 1">
+                  <CardProgressBar
+                    :progress="
+                      tree.seedId === 1
+                        ? (
+                            (tree.readingPage * 100.0) /
+                            tree.bookTotalPage
+                          ).toFixed(1)
+                        : 0
+                    "
+                    :readingPage="tree.readingPage"
+                    :totalPage="tree.totalPage"
+                  />
+                </div>
+                <CardReactNumbers
                   :leaf="tree.treeLeafCnt"
                   :like="tree.treeLikeCnt"
                   :view="tree.treeViewCnt"
-                  :progress="
-                    tree.seedId === 1
-                      ? (
-                          (tree.readingPage * 100.0) /
-                          tree.bookTotalPage
-                        ).toFixed(1)
-                      : 0
-                  "
-                >
-                  <h4 class="none">트리 진행률</h4>
-                  <div v-if="tree.seedId === 1">
-                    <CardProgressBar
-                      :progress="progress"
-                      :readingPage="readingPage"
-                      :totalPage="totalPage"
-                    />
-                  </div>
-                  <CardReactNumbers :leaf="leaf" :like="like" :view="view" />
-                </section>
-              </li>
-            </ul>
-          </section>
+                />
+              </section>
+            </li>
+          </ul>
         </section>
       </section>
-
-      <section class="my-tree-list">
-        <h2 class="none">나의 트리 목록</h2>
-        <div>{{ treeInfoList.length }}</div>
-        <section id="seed-filter">
-          <h2 class="none">트리 정렬 필터 버튼</h2>
-          <div>
-            <FilterTreeList :seedList="seedList" />
-          </div>
-        </section>
-      </section>
-
-      <section>
-        <h2 class="none">트리 검색 결과</h2>
-        <section class="tree-card-list" id="tree-card-list">
-          <h3 class="none">트리 검색 리스트</h3>
-          <div
-            class="card-tree-details"
-            v-for="tree in treeInfoList"
-            :key="tree.id"
-          >
-            <CardTreeDetails :tree="tree" />
-          </div>
-        </section>
-      </section>
-    </main>
-
-    <footer>
-      <Footer :noticeText="`개발중입니다.`" />
-    </footer>
-
-    <section class="nav-back-container">
-      <h3 class="none">네비 바 뒤 공백</h3>
     </section>
 
-    <aside class="nav-container">
-      <section class="short-btn-container">
-        <h4 class="none">트리 생성 버튼</h4>
-        <BtnShortGreen href="/seed/index" text="트리 생성" />
+    <section class="my-tree-list">
+      <h2 class="none">나의 트리 목록</h2>
+      <TextTreeCount :num="treeInfoList.length" />
+      <section id="seed-filter">
+        <h2 class="none">트리 정렬 필터 버튼</h2>
+        <div>
+          <FilterTreeList :seedList="seedList" />
+        </div>
       </section>
-      <NavigationBar active="home" />
-    </aside>
-  </body>
+    </section>
+
+    <section>
+      <h2 class="none">트리 검색 결과</h2>
+      <section class="tree-card-list" id="tree-card-list">
+        <h3 class="none">트리 검색 리스트</h3>
+        <div
+          class="card-tree-details"
+          v-for="tree in treeInfoList"
+          :key="tree.treeId"
+        >
+          <CardTreeDetails :tree="tree" />
+        </div>
+      </section>
+    </section>
+  </main>
+
+  <footer>
+    <Footer :noticeText="`개발중입니다.`" />
+  </footer>
+
+  <section class="nav-back-container">
+    <h3 class="none">네비 바 뒤 공백</h3>
+  </section>
+
+  <aside class="nav-container">
+    <section class="short-btn-container">
+      <h4 class="none">트리 생성 버튼</h4>
+      <ButtonBtnShortAGreen :link="`/seed/index`" :text="`트리 생성`" />
+    </section>
+    <NavNavigationBar active="home" />
+  </aside>
 </template>
 
 <style></style>

--- a/frontend-2/pages/home/index.vue
+++ b/frontend-2/pages/home/index.vue
@@ -1,6 +1,5 @@
 <script setup>
 import _ from "lodash";
-import "@toast-ui/editor/dist/toastui-editor.css";
 
 import { onBeforeMount, onMounted, reactive } from "vue";
 
@@ -8,44 +7,65 @@ import { onBeforeMount, onMounted, reactive } from "vue";
 
 const config = useRuntimeConfig();
 const treeInfoList = ref([]);
+const filterTreeInfoList = ref([]);
 const seedList = ref([]);
+const seedId = ref(0);
 let observer = null;
 
 //TODO: JWT토큰 있다면 전송하게끔 로직 수정 필요
-const fetchData = async () => {
-  const { data: seedData, status: seedStatus } = await useFetch("seeds", {
+
+const { data: seedData, status: seedStatus } = await useFetch("seeds", {
+  baseURL: `${config.public.apiBase}`,
+  method: "GET",
+});
+
+const { data: treeData, status: treeStatus } = await useFetch(
+  "trees/tree-home",
+  {
     baseURL: `${config.public.apiBase}`,
     method: "GET",
-  });
-  const { data: treeData, status: treeStatus } = await useFetch(
-    "trees/tree-home",
+    params: {
+      mid: useRoute().query.mid,
+    },
+  }
+);
+
+const newTreeFetch = async (newSeedId) => {
+  seedId.value = newSeedId;
+  const { data: filterTreeData, status: filterTreeStatus } = await useFetch(
+    "trees/tree-home-sort",
     {
       baseURL: `${config.public.apiBase}`,
       method: "GET",
       params: {
+        seedId: seedId.value,
         mid: useRoute().query.mid,
       },
     }
   );
-
-  watchEffect(() => {
-    if (treeStatus.value === "success" && treeData.value) {
-      treeInfoList.value = [...treeData.value.treeInfoResponseList];
-    } else {
-      console.log("treeData.value is null");
-    }
-
-    if (seedStatus.value === "success" && seedData.value) {
-      seedList.value = [...seedData.value.items];
-    } else {
-      console.log("seedData.value is null");
-    }
-  });
+  if (filterTreeStatus.value === "success" && filterTreeData.value) {
+    console.log("ok");
+    filterTreeInfoList.value = [...filterTreeData.value.treeInfoResponseList];
+  }
 };
 
+watchEffect(() => {
+  if (treeStatus.value === "success" && treeData.value) {
+    treeInfoList.value = [...treeData.value.treeInfoResponseList];
+    filterTreeInfoList.value = [...treeData.value.treeInfoResponseList];
+  } else {
+    console.log("treeData.value is null");
+  }
+
+  if (seedStatus.value === "success" && seedData.value) {
+    seedList.value = [...seedData.value.items];
+  } else {
+    console.log("seedData.value is null");
+  }
+});
+
 //-------------------LifeCycle-------------------
-onMounted(async () => {
-  await fetchData();
+onMounted(() => {
   const carouselList = document.querySelector(".tree-book-bg__list");
   // carousel item 너비
   // const width = document.querySelector(".mid__item").clientWidth;
@@ -55,10 +75,9 @@ onMounted(async () => {
   const carouselItems = document.querySelectorAll(".mid__item");
   // carousel item 전체 갯수
   const carouselItemCount = carouselItems.length / 3;
-
+  const container = carouselList.querySelector(".tree-book-bg");
   if (!import.meta.env.SSR) {
     // ----- 한 가운데 item 찾아내기 위한 IntersectionObserver코드 --------
-    // const container = carouselList.querySelector(".tree-book-bg");
     observer = new IntersectionObserver(
       (entries) => {
         let selectedElement = null;
@@ -75,7 +94,7 @@ onMounted(async () => {
           bookExRemoveNone(selectedElement);
         }
       },
-      { threshold: 0.3 }
+      { root: container, threshold: 0.3 }
     );
 
     carouselItems.forEach((item) => {
@@ -368,7 +387,7 @@ onMounted(async () => {
       <section id="seed-filter">
         <h2 class="none">트리 정렬 필터 버튼</h2>
         <div>
-          <FilterTreeList :seedList="seedList" />
+          <FilterTreeList :seedList="seedList" @seed-filter="newTreeFetch" />
         </div>
       </section>
     </section>
@@ -377,9 +396,21 @@ onMounted(async () => {
       <h2 class="none">트리 검색 결과</h2>
       <section class="tree-card-list" id="tree-card-list">
         <h3 class="none">트리 검색 리스트</h3>
+        <div v-if="filterTreeInfoList.length === 0">
+          <div class="tree-card-list__main">
+            <div class="card-tree__img-frame-no-tree">
+              <img
+                class="card-tree__book-cover"
+                src="/png/no-tree-mid-book.png"
+                alt="treeCover"
+              />
+            </div>
+            <p class="text--title20">조회된 트리가 없습니다.</p>
+          </div>
+        </div>
         <div
           class="card-tree-details"
-          v-for="tree in treeInfoList"
+          v-for="tree in filterTreeInfoList"
           :key="tree.treeId"
         >
           <CardTreeDetails :tree="tree" />

--- a/frontend-2/pages/memoir/[id]/edit.vue
+++ b/frontend-2/pages/memoir/[id]/edit.vue
@@ -2,9 +2,6 @@
 import { onBeforeMount, onMounted, ref } from "vue";
 import Editor from "@toast-ui/editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
-import LInkOneImageDetail from "~/components/link/LinkOneImageDetail.vue";
-import SubmitBtnFullBar from "~/components/button/SubmitBtnFullBar.vue";
-import NavigationBar from "~/components/nav/NavigationBar.vue";
 
 //----------------variable----------------
 //save 호출 API
@@ -151,7 +148,6 @@ onMounted(async () => {
 //     book.value = data.value.book;
 //   }
 // });
-
 </script>
 
 <template>
@@ -175,7 +171,7 @@ onMounted(async () => {
       <h3 class="none">도서 커버 및 도서 정보</h3>
       <section class="tree-reg-cover__container">
         <h4 class="none">도서 커버</h4>
-        <LInkOneImageDetail
+        <LinkOneImageDetail
           :src="`book/${book.bookImage}`"
           :href="'javascript:history.back()'"
         />
@@ -248,7 +244,7 @@ onMounted(async () => {
     <section class="register__input-container--last">
       <h3 class="none">회고록 생성 버튼</h3>
       <!-- 컴포넌트 -->
-      <SubmitBtnFullBar :text="'회고록 수정하기'" @click="editPost" />
+      <ButtonSubmitBtnFullBar :text="'회고록 수정하기'" @click="editPost" />
     </section>
   </main>
 
@@ -259,7 +255,7 @@ onMounted(async () => {
   <aside>
     <section class="nav-container">
       <h2 class="none">네비게이션 바</h2>
-      <NavigationBar :active="`home`" />
+      <NavNavigationBar :active="`home`" />
     </section>
   </aside>
 </template>


### PR DESCRIPTION
## 홈 화면 구현 완료
- JWT 도입 전까지는 mid(memberId)로 소유자를 식별합니다. 파라미터에 mid를 넣어줘야 합니다.

## 트리 리스트 api 새로 구현
- queryDsl이용해 트리 리스트 가져오는 새 API를 만들었습니다. 요청 url은 `trees/tree-home?mid=` 입니다.
- 기존 TreeInfoResponse 결과와 동일하되, fetchJoin을 적용해 요청 쿼리를 줄였습니다.