### PR TITLE
[기능] #241 프론트 구글 로그인, 상태 유지 구현

### DIFF
--- a/backend-2/src/main/java/io/ggogit/ggogit/util/JwtTokenProvider.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/util/JwtTokenProvider.java
@@ -32,7 +32,7 @@ public class JwtTokenProvider {
         claims.put("id", member.getId());
         claims.put("username", member.getUsername());
         claims.put("email", member.getEmail());
-        claims.put("role", member.getRole());
+        claims.put("roles", member.getRole());
 
         long expirationTime = isRefreshToken ? refreshExpirationTime : accessExpirationTime; // 만료 시간 설정
         return createToken(claims, member.getEmail(), expirationTime);

--- a/backend-2/src/main/resources/data.sql
+++ b/backend-2/src/main/resources/data.sql
@@ -16,7 +16,8 @@ VALUES
     (10, '2024-10-10 19:00:00', 'user10@example.com', 'Introduction of user10', false, 'nickname10', 'password10hash', '2024-10-10 19:00:00', 'user10', 1, 'USER'),
     (227, '2024-10-10 19:00:00', 'admin227@ggogit.io', 'Introduction of userTest', false, 'treeTest', 'treeAPI', '2024-10-10 19:00:00', 'API', 1, 'ADMIN'),
     (999, '2024-10-10 19:00:00', 'admin@ggogit.io', 'Introduction of user10', false, 'API', 'API', '2024-10-10 19:00:00', 'API', 1, 'ADMIN'),
-    (998, '2024-10-10 19:00:00', 'gksxorb147@naver.com', 'Introduction of user10', false, 'API', '$2a$10$YOSCvr2AcsMbSv36aYWFp.14..6ruvlkD3/QabL2FowYffwr26XWO', '2024-10-10 19:00:00', 'API', 1, 'ADMIN');
+    (998, '2024-10-10 19:00:00', 'gksxorb147@naver.com', 'Introduction of user10', false, 'API', '$2a$10$YOSCvr2AcsMbSv36aYWFp.14..6ruvlkD3/QabL2FowYffwr26XWO', '2024-10-10 19:00:00', 'API', 1, 'ADMIN'),
+    (997, '2024-10-10 19:00:00', 'test@naver.com', 'Introduction of user10', false, 'API', '$2a$10$cQ4tsAT3IoQkyKpoNH6Lf.DKE8dN9pSJGgRtY0SyxnbmjlJD.DWx6', '2024-10-10 19:00:00', 'API', 1, 'ADMIN');
 
 ALTER TABLE `member` ALTER COLUMN id RESTART WITH 100000;
 

--- a/frontend-2/components/link/SocialLogin.vue
+++ b/frontend-2/components/link/SocialLogin.vue
@@ -1,22 +1,36 @@
-<script setup lang="ts"></script>
+<script setup>
+import { GoogleLogin } from "vue3-google-login";
+
+const memberDetail = useMemberDetail();
+const config = useRuntimeConfig();
+
+const googleLoginHandler = async (googleUser) => {
+  console.log(googleUser);
+  //리소스 서버에 전송 후 memberDetail 발급받아야 함.
+
+  //이후 memberDetail이용한 상태 유지 필요
+};
+</script>
 
 <template>
   <div class="social-login">
     <div class="social-login__icons">
+      <GoogleLogin @success="googleLoginHandler">
+        <img src="/public/svg/google-circle.svg" alt="`구글 로그인`" />
+      </GoogleLogin>
       <a href="#"
-        ><div><img src="/public/svg/naver-circle.svg" alt="" /></div
+        ><div>
+          <img src="/public/svg/naver-circle.svg" alt="`네이버 로그인`" /></div
       ></a>
       <a href="#"
-        ><div><img src="/public/svg/google-circle.svg" alt="" /></div
-      ></a>
-      <a href="#"
-        ><div><img src="/public/svg/kakao-circle.svg" alt="" /></div
+        ><div>
+          <img src="/public/svg/kakao-circle.svg" alt="`카카오 로그인`" /></div
       ></a>
     </div>
   </div>
 </template>
 
-<style>
+<style scoped>
 /*===============================================
     FRAGMENT: 소셜 로그인
 ===============================================*/

--- a/frontend-2/composables/useMemberDetail.js
+++ b/frontend-2/composables/useMemberDetail.js
@@ -1,0 +1,66 @@
+import { defineStore } from "pinia";
+
+export const useMemberDetail = defineStore("ggogitMember", () => {
+  const id = ref("");
+  const username = ref("");
+  const email = ref("");
+  const roles = ref([]);
+  const token = ref("");
+
+  function isAnonymous() {
+    return email.value === "";
+  }
+
+  function setAuth(loginInfo) {
+    id.value = loginInfo.id;
+    username.value = loginInfo.username;
+    email.value = loginInfo.email;
+    roles.value = loginInfo.roles;
+    token.value = loginInfo.token;
+
+    if (!import.meta.env.SSR) {
+      localStorage.setItem("_ggogit_id", id.value);
+      localStorage.setItem("_ggogit_username", username.value);
+      localStorage.setItem("_ggogit_email", email.value);
+      localStorage.setItem("_ggogit_roles", JSON.stringify(roles.value));
+      localStorage.setItem("_ggogit_token", token.value);
+    }
+  }
+
+  const loadUserFromStorage = () => {
+    if (!import.meta.env.SSR) {
+      if (!localStorage.getItem("_ggogit_id")) return;
+
+      id.value = localStorage.getItem("_ggogit_id");
+      username.value = localStorage.getItem("_ggogit_username");
+      email.value = localStorage.getItem("_ggogit_email");
+      roles.value = JSON.parse(localStorage.getItem("_ggogit_roles"));
+      token.value = localStorage.getItem("_ggogit_token");
+    }
+  };
+
+  function initAuth() {
+    id.value = 0;
+    username.value = "";
+    email.value = "";
+    roles.value = [];
+    token.value = "";
+  }
+
+  function hasRole(role) {
+    return roles.value.includes(role);
+  }
+
+  return {
+    id,
+    username,
+    email,
+    roles,
+    token,
+    isAnonymous,
+    hasRole,
+    setAuth,
+    initAuth,
+    loadUserFromStorage,
+  };
+});

--- a/frontend-2/middleware/auth.global.js
+++ b/frontend-2/middleware/auth.global.js
@@ -1,0 +1,11 @@
+export default defineNuxtRouteMiddleware((to, from) => {
+  const userDetails = useMemberDetail();
+  //to.path는 사용자가 이동하려는(요청한) 경로를 나타낸다.
+  if (to.path.startsWith("/home, /tree, /leaf, /memoir")) {
+    // 로그인 여부를 확인하고 로그인하지 않은 사용자는 로그인 페이지로 이동시킨다.
+    if (userDetails.isAnonymous()) {
+      //리턴 URL을 포함시켜준다.
+      return navigateTo("/member/login?returnURL=" + `${to.fullPath}`);
+    }
+  }
+});

--- a/frontend-2/nuxt.config.ts
+++ b/frontend-2/nuxt.config.ts
@@ -21,7 +21,7 @@ export default defineNuxtConfig({
       "tree/book/new": {
         ssr: false, // "/editor/toast" 경로에 대해서는 SSR을 비활성화
       },
-      "leaf": {
+      leaf: {
         ssr: false, // 화면에 따른 window 객체의 값으로 인해 SSR을 비활성화
       },
       "leaf/book/new": {
@@ -60,9 +60,16 @@ export default defineNuxtConfig({
       "leaf/:id": {
         ssr: false, // "/editor/toast" 경로에 대해서는 SSR을 비활성화
       },
+      "member/login": {
+        ssr: false,
+      },
+      "member/email-send": {
+        ssr: false,
+      },
     },
   },
+  modules: ["@pinia/nuxt"],
   router: {
-    middleware: ['checkTreeFormData']
+    middleware: ["checkTreeFormData"],
   },
 });

--- a/frontend-2/package-lock.json
+++ b/frontend-2/package-lock.json
@@ -7,15 +7,18 @@
       "name": "nuxt-app",
       "hasInstallScript": true,
       "dependencies": {
+        "@pinia/nuxt": "^0.7.0",
         "@toast-ui/editor": "^3.2.2",
         "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
         "axios": "^1.7.7",
         "frontend": "file:",
+        "jwt-decode": "^4.0.0",
         "lodash": "^4.17.21",
         "nuxt": "^3.13.2",
         "nuxt-app": "file:",
-        "vue": "^3.5.12",
-        "vue-router": "^4.4.5"
+        "vue": "latest",
+        "vue-router": "latest",
+        "vue3-google-login": "^2.0.33"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1625,6 +1628,18 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/@pinia/nuxt": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@pinia/nuxt/-/nuxt-0.7.0.tgz",
+      "integrity": "sha512-IAKRl7mQCrFKQtD8Z6EzOz5bQ/px0FdeyaB+70A3igkFzHzKVJVblLCjFwXPBC/IO0EwHuMRk/SMgwkUn82jwg==",
+      "dependencies": {
+        "@nuxt/kit": "^3.9.0",
+        "pinia": "^2.2.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4915,6 +4930,14 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -6397,6 +6420,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.2.6.tgz",
+      "integrity": "sha512-vIsR8JkDN5Ga2vAxqOE2cJj4VtsHnzpR1Fz30kClxlh0yCHfec6uoMeM3e/ddqmwFUejK3NlrcQa/shnpyT4hA==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.0",
+        "typescript": ">=4.4.4",
+        "vue": "^2.6.14 || ^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/pkg-types": {
@@ -9031,6 +9079,31 @@
         "ufo": "^1.5.4"
       }
     },
+    "node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/vue-devtools-stub": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/vue-devtools-stub/-/vue-devtools-stub-0.1.0.tgz",
@@ -9048,6 +9121,14 @@
       },
       "peerDependencies": {
         "vue": "^3.2.0"
+      }
+    },
+    "node_modules/vue3-google-login": {
+      "version": "2.0.33",
+      "resolved": "https://registry.npmjs.org/vue3-google-login/-/vue3-google-login-2.0.33.tgz",
+      "integrity": "sha512-Hx3JJUREXWCFOOB4AzZKy/x7C+X18kxmT0AquBekm0TRubp11nrWijOLEgmhuij48dQPNumyaAi5IQAeDKk7yw==",
+      "peerDependencies": {
+        "vue": "^3.0.3"
       }
     },
     "node_modules/w3c-keyname": {

--- a/frontend-2/package.json
+++ b/frontend-2/package.json
@@ -10,14 +10,20 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
+    "@pinia/nuxt": "^0.7.0",
     "@toast-ui/editor": "^3.2.2",
     "@toast-ui/editor-plugin-code-syntax-highlight": "^3.1.0",
     "axios": "^1.7.7",
     "frontend": "file:",
+    "jwt-decode": "^4.0.0",
     "lodash": "^4.17.21",
     "nuxt": "^3.13.2",
     "nuxt-app": "file:",
-    "vue": "^3.5.12",
-    "vue-router": "^4.4.5"
+    "vue": "latest",
+    "vue-router": "latest",
+    "vue3-google-login": "^2.0.33"
+  },
+  "overrides": {
+    "vue": "latest"
   }
 }

--- a/frontend-2/pages/member/login.vue
+++ b/frontend-2/pages/member/login.vue
@@ -1,30 +1,144 @@
-<script setup lang="ts">
+<script setup>
+import { jwtDecode } from "jwt-decode";
+import { errorMessages } from "vue/compiler-sfc";
+
+const config = useRuntimeConfig();
+
+const memberDetail = useMemberDetail();
+const memberRequest = ref({
+  email: "",
+  password: "",
+});
+
+const loginHandler = async () => {
+  try {
+    const response = await $fetch("/members/login", {
+      method: "POST",
+      baseURL: `${config.public.apiBase}`,
+      body: memberRequest.value,
+    });
+    const memberInfo = jwtDecode(response.accessToken);
+    console.log(memberInfo);
+    memberDetail.setAuth(memberInfo);
+    const returnURL = route.query.returnURL || "/";
+    return useRouter().push(returnURL);
+  } catch (error) {
+    alert(error.data?.message);
+  }
+};
 </script>
 
 <template>
   <div class="login-member__join-page-container">
     <ButtonLoginJoinPageBackBtn />
     <TextLoginPageInfo />
-    <InputTextBar
-        label="이메일"
-        name="email"
-        placeholder="이메일을 입력해주세요."
-    />
-    <InputTextBar
-        label="비밀번호"
-        name="password"
-        placeholder="비밀번호를 입력해주세요."
-    />
-    <ButtonSubmitBtnFullBar text="로그인" />
+    <div class="input-text__bar">
+      <label class="input-text__label">
+        <span class="input-text__label-text">이메일</span>
+        <input
+          class="input-text__input"
+          placeholder="이메일을 입력해주세요"
+          autocomplete="off"
+          v-model="memberRequest.email"
+        />
+      </label>
+    </div>
+    <div class="input-text__bar">
+      <label class="input-text__label">
+        <span class="input-text__label-text">비밀번호</span>
+        <input
+          class="input-text__input"
+          placeholder="비밀번호를 입력해주세요"
+          autocomplete="off"
+          type="password"
+          v-model="memberRequest.password"
+        />
+      </label>
+    </div>
+    <div class="btn-full-bar">
+      <button
+        id="book-tree-input-form-id"
+        class="btn-full-bar__btn"
+        @click.prevent="loginHandler"
+      >
+        로그인
+      </button>
+    </div>
     <LinkSocialLogin />
-    <TextJoinGuide />
+    <TextJoinGuide :href="`/member/email-send`" />
   </div>
 </template>
 
 <style scoped>
-
 .login-member__join-page-container {
   width: auto;
   padding: 50px 24px 0 24px;
+}
+.btn-full-bar {
+  width: 100%;
+  height: 56px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 30px 0 30px 0;
+}
+
+.btn-full-bar__btn {
+  color: var(--white, #ffffff);
+  background-color: var(--main1, #323a27);
+  height: 56px;
+  width: 100%;
+  border-radius: 20px;
+  box-shadow: var(--shadow-basic);
+  font-size: 18px;
+  font-weight: var(--bold, 700);
+}
+.input-text__label {
+  display: flex;
+  gap: 8px;
+  flex-direction: column;
+  width: 100%;
+  position: relative;
+  padding: 30px 0 0 0;
+}
+
+.input-text__label-text {
+  font-weight: var(--semi-bold);
+  font-size: 18px;
+}
+
+.input-text__input {
+  width: auto;
+  height: 56px;
+  display: flex;
+  border: none;
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: var(--regular);
+  color: var(--text-sub);
+  padding-left: 16px;
+  background-color: var(--main3, #e5eddb);
+}
+
+.input-text__input--warning {
+  outline: 2px solid var(--warning);
+}
+
+.input-text__input:focus {
+  outline: 2px solid var(--filter-checked);
+}
+
+.input-text__input:not(:placeholder-shown) {
+  color: var(--text-main);
+  outline: 2px solid var(--main1, #323a27);
+}
+
+.input-text__input-wrong {
+  margin: 12px 0 0 12px;
+  color: var(--warning, #ba0c0c);
+}
+.input-text__input:read-only {
+  background-color: var(--main2, #e5eddb);
+  outline: 3px solid var(--gray);
 }
 </style>

--- a/frontend-2/plugins/auth-reload.js
+++ b/frontend-2/plugins/auth-reload.js
@@ -1,0 +1,8 @@
+export default defineNuxtPlugin((Nuxtapp) => {
+  const memberDetail = useMemberDetail();
+
+  // 로컬 스토리지에 저장된 사용자 정보 로드
+  if (!import.meta.env.SSR) {
+    memberDetail.loadUserFromStorage();
+  }
+});

--- a/frontend-2/plugins/google-login.client.js
+++ b/frontend-2/plugins/google-login.client.js
@@ -1,0 +1,9 @@
+import { defineNuxtPlugin } from "#app";
+import vue3GoogleLogin from "vue3-google-login";
+
+export default defineNuxtPlugin((nuxtApp) => {
+  nuxtApp.vueApp.use(vue3GoogleLogin, {
+    clientId:
+      "56165295668-cmnhabamv9b6bpsbcc0mbtrpqhiqtu36.apps.googleusercontent.com",
+  });
+});


### PR DESCRIPTION
## 구글 로그인 구현
- 로그인 페이지의 구글 버튼을 누르면 구글 로그인이 진행됩니다.
- 구글이 전송한 jwt를 전송할 API는 작성되지 않았습니다.

### 주의점
- 제 구글 설정에서 허용되는 호스트가 localhost:3000이기 때문에 로컬 서버가 호스트가 192... 등으로 시작하면, 이를 직접 localhost:로 고쳐주셔야 합니다.

## 로컬 로그인 구현
- 로그인 페이지에서 입력받고, 이를 서버에 보낸 후 받아온 jwt를 디코드해 로컬스토리지에 저장하도록 했습니다.
- 로그인 실패시 뜨는 메시지의 종류를 더 상냥하게 고칠 필요가 있어보입니다.
- jwt의 클레임에 포함될 데이터도 추가할 필요가 있습니다.