### PR TITLE
[기능] #258 로컬 로그인 구현

### DIFF
--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
@@ -86,8 +86,7 @@ public class TreeController {
     @GetMapping("{id}/info")
     public ResponseEntity<TreeInfoResponse> getTreeInfoResponse(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable(value = "id") Long treeId,
-            @RequestParam(value = "mid",defaultValue = "1") Long mid
+            @PathVariable(value = "id") Long treeId
     ) {
         Long memberId = userDetails.getId();
         TreeInfoResponse treeInfoResponse = treeService.findTreeInfoResponse(memberId, treeId);
@@ -239,9 +238,9 @@ public class TreeController {
 //    }
     @GetMapping("tree-home")
     public ResponseEntity<TreeInfoResponseHome> getTreeInfoResponses(
-            @RequestParam(value = "mid",defaultValue = "1") Long mid) {
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        Long memberId = mid;
+        Long memberId = userDetails.getId();
         List<TreeInfoResponse> treeInfoResponseList = treeService.findTreeInfoResponseList(memberId);
 
         return new ResponseEntity<>(TreeInfoResponseHome.of(treeInfoResponseList), HttpStatus.OK);
@@ -249,10 +248,10 @@ public class TreeController {
 
     @GetMapping("tree-home-sort")
     public ResponseEntity<TreeInfoResponseHome> getTreeInfoResponsesSort(
-            @RequestParam(value = "mid",defaultValue = "1") Long mid,
-            @RequestParam(value = "seedId", required = false) Long seedId
+            @RequestParam(value = "seedId", required = false) Long seedId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long memberId = mid;
+        Long memberId = userDetails.getId();
         List<TreeInfoResponse> treeInfoResponseList = treeService.findTreeInfoResponseList(memberId, seedId);
 
         return new ResponseEntity<>(TreeInfoResponseHome.of(treeInfoResponseList), HttpStatus.OK);

--- a/backend-2/src/main/java/io/ggogit/ggogit/util/JwtTokenProvider.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/util/JwtTokenProvider.java
@@ -33,7 +33,6 @@ public class JwtTokenProvider {
         claims.put("username", member.getUsername());
         claims.put("nickname", member.getNickname());
         claims.put("email", member.getEmail());
-        claims.put("nickname", member.getNickname());
         claims.put("roles", member.getRole());
 
         long expirationTime = isRefreshToken ? refreshExpirationTime : accessExpirationTime; // 만료 시간 설정
@@ -99,6 +98,6 @@ public class JwtTokenProvider {
 
 
     private Key getBase64SecretKey() {
-        return Keys.hmacShaKeyFor(Base64.getEncoder().encode(secretKey.getBytes(StandardCharsets.UTF_8)));
+        return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
     }
 }

--- a/frontend-2/composables/useAuthDataFetch.js
+++ b/frontend-2/composables/useAuthDataFetch.js
@@ -1,0 +1,22 @@
+import { useMemberDetail } from "./useMemberDetail";
+
+export default async function useAuthFetch(url, options = {}) {
+  // 1. MemberDetail에서 token을 획득
+  const { token = {} } = useMemberDetail();
+
+  // 2. 획득한 token을 헤더에 담기
+  options.headers = {
+    ...options.headers,
+    Authorization: `Bearer ${token}`,
+  };
+
+  // 3. 사용자가 요청한 url과 option에, 획득한 token을 담아서 fetch 요청하기
+  const { data, status, error } = await useFetch(url, options);
+
+  // 4. fetch의 data, error, status 등을 반환(useFetch와 유사한 형태)
+  console.log(data);
+  console.log(status);
+  console.log(error);
+
+  return { data, error, status };
+}

--- a/frontend-2/composables/useAuthDataFetch.js
+++ b/frontend-2/composables/useAuthDataFetch.js
@@ -2,12 +2,12 @@ import { useMemberDetail } from "./useMemberDetail";
 
 export default async function useAuthFetch(url, options = {}) {
   // 1. MemberDetail에서 token을 획득
-  const { token = {} } = useMemberDetail();
+  const _accessToken = useMemberDetail().getAuthToken() || "";
 
   // 2. 획득한 token을 헤더에 담기
   options.headers = {
     ...options.headers,
-    Authorization: `Bearer ${token}`,
+    Authorization: `Bearer ${_accessToken}`,
   };
 
   // 3. 사용자가 요청한 url과 option에, 획득한 token을 담아서 fetch 요청하기

--- a/frontend-2/composables/useAuthFetch.js
+++ b/frontend-2/composables/useAuthFetch.js
@@ -2,12 +2,12 @@ import { useMemberDetail } from "./useMemberDetail";
 
 export default async function useAuthFetch(url, options = {}) {
   // 1. MemberDetail에서 token을 획득
-  const { token = {} } = useMemberDetail();
+  const _accessToken = useMemberDetail().getAuthToken() || "";
 
   // 2. 획득한 token을 헤더에 담기
   options.headers = {
     ...options.headers,
-    Authorization: `Bearer ${token}`,
+    Authorization: `Bearer ${_accessToken}`,
   };
 
   // 3. 사용자가 요청한 url과 option에, 획득한 token을 담아서 fetch 요청하기

--- a/frontend-2/composables/useAuthFetch.js
+++ b/frontend-2/composables/useAuthFetch.js
@@ -1,0 +1,25 @@
+import { useMemberDetail } from "./useMemberDetail";
+
+export default async function useAuthFetch(url, options = {}) {
+  // 1. MemberDetail에서 token을 획득
+  const { token = {} } = useMemberDetail();
+
+  // 2. 획득한 token을 헤더에 담기
+  options.headers = {
+    ...options.headers,
+    Authorization: `Bearer ${token}`,
+  };
+
+  // 3. 사용자가 요청한 url과 option에, 획득한 token을 담아서 fetch 요청하기
+  const response = await fetch(url, options);
+
+  // 4. fetch의 data, error, status 등을 반환(useFetch와 유사한 형태)
+  const data = await response.json();
+  console.log(data);
+  const status = response.status;
+  console.log(status);
+  const error = !response.ok ? data : null;
+  console.log(error);
+
+  return { data, error, status };
+}

--- a/frontend-2/composables/useMemberDetail.js
+++ b/frontend-2/composables/useMemberDetail.js
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import {jwtDecode} from "jwt-decode";
+import { jwtDecode } from "jwt-decode";
 
 export const useMemberDetail = defineStore("ggogitMember", () => {
   const _id = ref("");
@@ -15,10 +15,14 @@ export const useMemberDetail = defineStore("ggogitMember", () => {
 
   function setAuthWithToken(accessToken) {
     _accessToken.value = accessToken;
-    console.log('accessToken', _accessToken.value);
+    console.log("accessToken", _accessToken.value);
     const memberInfo = jwtDecode(_accessToken.value);
-    console.log('memberInfo', memberInfo);
+    console.log("memberInfo", memberInfo);
     setAuth(memberInfo);
+  }
+
+  function getAuthToken() {
+    return _accessToken.value;
   }
 
   function setAuth(loginInfo) {
@@ -34,6 +38,7 @@ export const useMemberDetail = defineStore("ggogitMember", () => {
       localStorage.setItem("_ggogit_nickname", _nickname.value);
       localStorage.setItem("_ggogit_email", _email.value);
       localStorage.setItem("_ggogit_roles", JSON.stringify(_roles.value));
+      localStorage.setItem("_ggogit_accessToken", _accessToken.value);
     }
   }
 
@@ -69,11 +74,12 @@ export const useMemberDetail = defineStore("ggogitMember", () => {
 
   return {
     setAuthWithToken,
+    getAuthToken,
     isAnonymous,
     hasRole,
     setAuth,
     initAuth,
     setEmail,
-    loadUserFromStorage
+    loadUserFromStorage,
   };
 });

--- a/frontend-2/middleware/auth.global.js
+++ b/frontend-2/middleware/auth.global.js
@@ -1,7 +1,10 @@
+import { useMemberDetail } from "#imports";
+
 export default defineNuxtRouteMiddleware((to, from) => {
   const userDetails = useMemberDetail();
   //to.path는 사용자가 이동하려는(요청한) 경로를 나타낸다.
-  if (to.path.startsWith("/home, /tree, /leaf, /memoir")) {
+  const protectedPaths = ["/home", "/tree", "/leaf", "/memoir"];
+  if (protectedPaths.some((path) => to.path.startsWith(path))) {
     // 로그인 여부를 확인하고 로그인하지 않은 사용자는 로그인 페이지로 이동시킨다.
     if (userDetails.isAnonymous()) {
       //리턴 URL을 포함시켜준다.

--- a/frontend-2/middleware/auth.global.js
+++ b/frontend-2/middleware/auth.global.js
@@ -8,7 +8,7 @@ export default defineNuxtRouteMiddleware((to, from) => {
     // 로그인 여부를 확인하고 로그인하지 않은 사용자는 로그인 페이지로 이동시킨다.
     if (userDetails.isAnonymous()) {
       //리턴 URL을 포함시켜준다.
-      return navigateTo("/member/login?returnURL=" + `${to.fullPath}`);
+      return navigateTo("/member/login?returnUrl=" + `${to.fullPath}`);
     }
   }
 });

--- a/frontend-2/pages/home/index.vue
+++ b/frontend-2/pages/home/index.vue
@@ -20,14 +20,11 @@ const { data: seedData, status: seedStatus } = await useFetch("seeds", {
   method: "GET",
 });
 
-const { data: treeData, status: treeStatus } = await useFetch(
+const { data: treeData, status: treeStatus } = await useAuthDataFetch(
   "trees/tree-home",
   {
     baseURL: `${config.public.apiBase}`,
     method: "GET",
-    params: {
-      mid: useRoute().query.mid,
-    },
   }
 );
 

--- a/frontend-2/pages/member/login.vue
+++ b/frontend-2/pages/member/login.vue
@@ -1,6 +1,5 @@
 <script setup>
-
-import {useMemberDetail} from "~/composables/useMemberDetail.js";
+import { useMemberDetail } from "~/composables/useMemberDetail.js";
 
 const config = useRuntimeConfig();
 const router = useRouter();
@@ -8,13 +7,13 @@ const memberDetail = useMemberDetail();
 
 // ----------------------- Model ----------------------- //
 const loginInfo = ref({
-  email: '',
+  email: "",
   isEmailValid: true,
-  emailValidateMessage: '이메일을 입력해주세요.',
+  emailValidateMessage: "이메일을 입력해주세요.",
 
-  password: '',
+  password: "",
   isPasswordValid: true,
-  passwordValidateMessage: '비밀번호를 입력해주세요.'
+  passwordValidateMessage: "비밀번호를 입력해주세요.",
 });
 // ----------------------- API ----------------------- //
 
@@ -23,23 +22,27 @@ const loginApi = async () => {
   try {
     // { "email": "gksxorb147@naver.com", "password": "mypassword" } < 테스트 데이터
     const response = await $fetch(`${config.public.apiBase}/members/login`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json'
+        "Content-Type": "application/json",
       },
       body: JSON.stringify({
         email: loginInfo.value.email,
-        password: loginInfo.value.password
-      })
+        password: loginInfo.value.password,
+      }),
     });
 
-    memberDetail.setAuthWithToken(response.accessToken, response.refreshToken);
-    router.push("/home");
+    memberDetail.setAuthWithToken(response.accessToken);
+    //현재 URL에서 returnUrl 값을 가져오기
+    const returnUrl = router.currentRoute.value.query.retrunUrl || "/home";
+    console.log("로그인 성공");
+    // 로그인 성공시 returnUrl로 이동
+    router.push(returnUrl);
   } catch (error) {
-    alert('로그인 실패');
+    console.log(error);
+    alert("로그인 실패");
   }
 };
-
 
 // ----------------------- Method ----------------------- //
 const inputEmail = (email) => {
@@ -51,12 +54,11 @@ const inputPassword = (password) => {
 };
 
 const submitHandler = () => {
-
   // 이메일 형식 확인
   const emailRegExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   if (!emailRegExp.test(loginInfo.value.email)) {
     loginInfo.value.isEmailValid = false;
-    loginInfo.value.emailValidateMessage = '이메일 형식이 올바르지 않습니다.';
+    loginInfo.value.emailValidateMessage = "이메일 형식이 올바르지 않습니다.";
   } else {
     loginInfo.value.isEmailValid = true;
   }
@@ -64,7 +66,7 @@ const submitHandler = () => {
   // 비밀번호 입력 확인
   if (loginInfo.value.password.length === 0) {
     loginInfo.value.isPasswordValid = false;
-    loginInfo.value.passwordValidateMessage = '비밀번호를 입력해주세요.';
+    loginInfo.value.passwordValidateMessage = "비밀번호를 입력해주세요.";
   } else {
     loginInfo.value.isPasswordValid = true;
   }
@@ -75,53 +77,55 @@ const submitHandler = () => {
 
   loginApi();
 };
-
 </script>
 
 <template>
   <div class="login-member__join-page-container">
     <ButtonLoginJoinPageBackBtn :data="{ link: '/' }" />
-    <TextLoginPageInfo :data="{
-      label: '로그인',
-      infoText: '이메일로 로그인을 진행합니다.'
-    }" />
+    <TextLoginPageInfo
+      :data="{
+        label: '로그인',
+        infoText: '이메일로 로그인을 진행합니다.',
+      }"
+    />
     <form @submit="submitHandler">
       <InputTextBar
-          :data="{
+        :data="{
           label: '이메일',
           name: 'email',
           placeholder: '이메일을 입력해주세요.',
           inputType: 'email',
           isValid: loginInfo.isEmailValid,
-          validateMessage: loginInfo.emailValidateMessage
+          validateMessage: loginInfo.emailValidateMessage,
         }"
-          @inputData="inputEmail"
+        @inputData="inputEmail"
       />
       <InputTextBar
-          :data="{
+        :data="{
           label: '비밀번호',
           name: 'password',
           placeholder: '비밀번호를 입력해주세요.',
           inputType: 'password',
           isValid: loginInfo.isPasswordValid,
-          validateMessage: loginInfo.passwordValidateMessage
+          validateMessage: loginInfo.passwordValidateMessage,
         }"
-          @inputData="inputPassword"
+        @inputData="inputPassword"
       />
-      <ButtonSubmitBtnFullBar text="로그인" @submit="submitHandler"/>
+      <ButtonSubmitBtnFullBar text="로그인" @submit="submitHandler" />
     </form>
     <LinkSocialLogin />
-    <TextJoinGuide :data="{
-      infoText: '계정이 없으신가요?',
-      label: '회원가입',
-      href: '/member/join/email',
-      isFind: true
-    }" />
+    <TextJoinGuide
+      :data="{
+        infoText: '계정이 없으신가요?',
+        label: '회원가입',
+        href: '/member/join/email',
+        isFind: true,
+      }"
+    />
   </div>
 </template>
 
 <style scoped>
-
 .login-member__join-page-container {
   width: auto;
   padding: 50px 24px 0 24px;


### PR DESCRIPTION
### 로컬 로그인 구현
- 다만 서버에서 전송되는 JWT내용이 부족합니다. 상태 유지를 위한 값들이 부족해서, 현재는 새로고침을 하면 다시 로그인을 진행해야 합니다.
- 추가로 서버에서 전송해준 JWT가 부족한데도, 이 토큰을 그대로 리소스 요청때 헤더에 담아서 보내면 memberId를 꺼내서 사용하는 듯 합니다. **리소스 서버가 쿼리를 날리는데는 에러가 없는 상황입니다.**
-  이걸 보면 어딘가에 담겨있는데도, `jwtDecode` 라이브러리가 클레임 까지 디코딩을 못해주는걸까 생각도 듭니다. 보안을 강화한 디코더 라이브러리에서는 디코딩시 secretKey를 요구하는 경우도 있다고 들었습니다.