### PR TITLE
[기능] #258 Fetch 교체, 상태유지, 로그아웃 구현

### DIFF
--- a/frontend-2/components/card/CardAnotherRecords.vue
+++ b/frontend-2/components/card/CardAnotherRecords.vue
@@ -164,6 +164,7 @@ function modifyCount(count: number) {
 }
 
 .card-another-records__top-anker {
+  width: 100%;
   display: flex;
   flex: 1 0 auto;
   gap: 8px;
@@ -174,6 +175,7 @@ function modifyCount(count: number) {
   width: 100%;
   height: 120px;
   display: flex;
+  flex-direction: column-reverse;
   justify-content: center;
 }
 
@@ -188,13 +190,13 @@ function modifyCount(count: number) {
 }
 
 .card-another-records__mid-box {
-  display: flex;
-  flex-direction: column;
+  width: 100%;
   align-items: flex-start;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-another-records__mid-seed-frame {
-  display: flex;
   gap: 4px;
 }
 
@@ -212,6 +214,9 @@ function modifyCount(count: number) {
   font-weight: var(--bold);
   line-height: var(--line-height-main);
   letter-spacing: var(--letter-spacing-main);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-another-records__mid-another--title--sub {
@@ -220,6 +225,9 @@ function modifyCount(count: number) {
   font-weight: var(--bold);
   line-height: var(--line-height-main);
   letter-spacing: var(--letter-spacing-main);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-another-records__mid-work-title {
@@ -228,6 +236,9 @@ function modifyCount(count: number) {
   font-weight: var(--medium);
   line-height: var(--line-height-sub);
   letter-spacing: var(--letter-spacing-sub);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-another-records__info {
@@ -236,12 +247,16 @@ function modifyCount(count: number) {
   font-weight: var(--medium);
   line-height: var(--line-height-sub);
   letter-spacing: var(--letter-spacing-sub);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-another-records__icon-box {
+  padding-top: 10px;
   height: 21px;
   display: flex;
-  justify-content: space-between;
+  flex-direction: row-reverse;
   align-items: center;
   gap: 8px;
 }
@@ -289,32 +304,44 @@ function modifyCount(count: number) {
   background-size: contain;
 }
 
+.card-another-records__bot-nickname-box {
+  width: 100%;
+}
+
 .card-another-records__bot-box {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
+  width: 100%;
+  height: auto;
 }
 
 .card-another-records-log-title {
+  width: 100%;
+  margin-top: 10px;
   color: var(--text-main);
   font-size: 18px;
   font-weight: var(--bold);
   line-height: var(--line-height-main);
   letter-spacing: var(--letter-spacing-main);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-another-records-log-content {
+  width: 100%;
   padding-top: 10px;
   color: var(--text-sub);
   font-size: 14px;
   font-weight: var(--regular);
   line-height: var(--line-height-sub);
   letter-spacing: var(--letter-spacing-sub);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-another-records__bot-box-etc-info {
   width: 100%;
-  margin-top: 10px;
+  margin-top: 15px;
   display: flex;
   justify-content: space-between;
 }

--- a/frontend-2/components/footer/Footer.vue
+++ b/frontend-2/components/footer/Footer.vue
@@ -14,9 +14,9 @@ const router = useRouter();
 const handleLogout = async () => {
   try {
     // 로그아웃 API 호출
-    await fetch("/member/logout", { method: "POST" });
+    useMemberStore().initAuth();
     // 로그아웃 성공 후 처리
-    router.push("/index");
+    router.push("/member/login");
   } catch (error) {
     console.error("로그아웃 실패:", error);
   }

--- a/frontend-2/components/input/InputBackSearch.vue
+++ b/frontend-2/components/input/InputBackSearch.vue
@@ -15,7 +15,7 @@ const emit = defineEmits([
   "totalCount",
   "totalPage",
   "dropListEvent",
-  "loading"
+  "loading",
 ]);
 //-----------------ref-----------------
 const bookResult = ref([]);
@@ -35,7 +35,7 @@ watch(page, () => {
 const createReq = async (query, filter, currentPage) => {
   try {
     emit("loading", true); // Emit loading event
-    const response = await $fetch(props.api, {
+    const response = await useAuthDataFetch(props.api, {
       method: "GET",
       params: {
         q: query,
@@ -66,7 +66,8 @@ const createReq = async (query, filter, currentPage) => {
     if (error.response && error.response.status === 400) {
       alert("검색어를 두 글자 이상 입력해 주세요.");
     } else {
-      alert("오류가 발생했습니다. 다시 시도해 주세요.");q
+      alert("오류가 발생했습니다. 다시 시도해 주세요.");
+      q;
     }
   } finally {
     emit("loading", false); // Emit loading event

--- a/frontend-2/components/input/InputBackSearchLeaf.vue
+++ b/frontend-2/components/input/InputBackSearchLeaf.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from "vue";
-import {value} from "lodash/seq.js";
+import { value } from "lodash/seq.js";
 //-----------------props-----------------
 const props = defineProps({
   placeholder: "",
@@ -21,7 +21,7 @@ const emit = defineEmits([
 //-----------------filter-----------------
 let filterQuery = 10;
 let sortQuery = 0;
-let searchQuery = 'title';
+let searchQuery = "title";
 
 //-----------------ref-----------------
 const result = ref([]);
@@ -32,43 +32,46 @@ const totalPage = ref(0);
 const filterName = ref("최근 수정 순");
 const searchFilterName = ref("제목 검색");
 const filter = ref(10);
-const searchFilter = ref('title');
+const searchFilter = ref("title");
 const sort = ref(0);
 //-----------------watcher-----------------
 // page 값이 변경될 때 요청
 watch(page, () => {
   if (page.value > 0) {
-    createReq(props.sort, page.value, searchFilter.value, filterQuery,false); // props.sort 사용
+    createReq(props.sort, page.value, searchFilter.value, filterQuery, false); // props.sort 사용
     console.log("new page");
   }
 });
 
 // sort 값이 변경될 때 요청
-watch(() => props.sort, (newSort) => {
-  console.log(`sort changed to ${newSort}`);
+watch(
+  () => props.sort,
+  (newSort) => {
+    console.log(`sort changed to ${newSort}`);
 
-  // 페이지를 초기화하고 새로운 정렬 기준으로 요청
-  page.value = 0;
+    // 페이지를 초기화하고 새로운 정렬 기준으로 요청
+    page.value = 0;
 
-  // 새로운 sort 값으로 fetch 요청
-  createReq(newSort, page.value, searchFilter.value, filterQuery, false);
-});
+    // 새로운 sort 값으로 fetch 요청
+    createReq(newSort, page.value, searchFilter.value, filterQuery, false);
+  }
+);
 
 //-----------------methods-----------------
 const createReq = async (sort, currentPage, searchFilter, filter, isChange) => {
   let queryContent = "";
-  if(isChange){
-    queryContent = query.value
+  if (isChange) {
+    queryContent = query.value;
   }
   try {
-    const response = await $fetch(props.api, {
+    const response = await useAuthDataFetch(props.api, {
       method: "GET",
       params: {
         query: queryContent,
         sort: sort,
         page: currentPage,
-        searchFilter : searchFilter,
-        filter : filter
+        searchFilter: searchFilter,
+        filter: filter,
       },
     });
 
@@ -84,8 +87,9 @@ const createReq = async (sort, currentPage, searchFilter, filter, isChange) => {
       result.value = [...result.value, ...response.content];
 
       // 중복 제거
-      result.value = [...new Set(result.value.map(value => value.leafId))].map((leafId) =>
-          result.value.find((value) => value.leafId === leafId));
+      result.value = [
+        ...new Set(result.value.map((value) => value.leafId)),
+      ].map((leafId) => result.value.find((value) => value.leafId === leafId));
 
       // 페이지 정보 업데이트
       page.value = currentPage;
@@ -105,7 +109,6 @@ const createReq = async (sort, currentPage, searchFilter, filter, isChange) => {
     emit("page", page.value);
     emit("totalCount", totalCount.value);
     emit("totalPage", totalPage.value);
-
   } catch (error) {
     if (error.response && error.response.status === 400) {
       alert("검색어를 두 글자 이상 입력해 주세요.");
@@ -120,46 +123,46 @@ const openPopup = () => {
   const filterBack2 = document.getElementById("filter-bg-blur");
   const filterTab = document.getElementById("filter-tab");
 
-  filterBack1.classList.remove('none');
-  filterBack2.classList.remove('none');
+  filterBack1.classList.remove("none");
+  filterBack2.classList.remove("none");
 
   setTimeout(() => {
-    filterTab.classList.add('up');
-  }, 30)
+    filterTab.classList.add("up");
+  }, 30);
 };
 
 const closePopup = () => {
   const filterBack1 = document.getElementById("filter-bg");
   const filterBack2 = document.getElementById("filter-bg-blur");
   const filterTab = document.getElementById("filter-tab");
-  filterTab.classList.remove('up');
-  filterBack1.classList.add('none');
-  filterBack2.classList.add('none');
+  filterTab.classList.remove("up");
+  filterBack1.classList.add("none");
+  filterBack2.classList.add("none");
 
   searchFilter.value = searchQuery;
   sort.value = sortQuery;
   page.value = 0;
 
-  if(query.value !== ""){
+  if (query.value !== "") {
     createReq(sort.value, page.value, searchFilter.value, filterQuery, false);
   }
   emit("filterName", filterName.value);
-}
+};
 
 const searchFilterHandler = (e) => {
   searchQuery = e;
   switch (e) {
-    case 'title':
+    case "title":
       searchFilterName.value = "제목 검색";
       break;
-    case 'content':
+    case "content":
       searchFilterName.value = "내용 검색";
       break;
-    case 'all':
+    case "all":
       searchFilterName.value = "제목 + 내용 검색";
       break;
   }
-}
+};
 
 const filterNameHandler = (e) => {
   filterQuery = e;
@@ -177,14 +180,14 @@ const filterNameHandler = (e) => {
       filterName.value = "좋아요 수 순";
       break;
   }
-}
+};
 const sortHandler = (e) => {
   sortQuery = e;
-}
+};
 
 const dropQueryHandler = () => {
   query.value = "";
-}
+};
 
 //-----------------lifeCycle-----------------
 onUpdated(() => {
@@ -212,7 +215,11 @@ onUpdated(() => {
           autocomplete="off"
           @keyup.enter="createReq(sort, 0, searchFilter, filter, true)"
         />
-        <button @click="dropQueryHandler" class="search-bar--close" type="reset">
+        <button
+          @click="dropQueryHandler"
+          class="search-bar--close"
+          type="reset"
+        >
           <img src="/public/svg/close-button.svg" alt="close-btn" />
         </button>
       </label>
@@ -224,11 +231,17 @@ onUpdated(() => {
 
   <div class="search-filter-frame">
     <div class="search-filter-frame-search">
-      <span @click.prevent="openPopup" class="search-filter-log__checkbox-input-img">
-          <img class="" src="/svg/sort-white.svg">
+      <span
+        @click.prevent="openPopup"
+        class="search-filter-log__checkbox-input-img"
+      >
+        <img class="" src="/svg/sort-white.svg" />
       </span>
-      <span @click.prevent="openPopup" class="search-filter-log__checkbox-input-text">
-        <p>{{searchFilterName}}</p>
+      <span
+        @click.prevent="openPopup"
+        class="search-filter-log__checkbox-input-text"
+      >
+        <p>{{ searchFilterName }}</p>
       </span>
     </div>
     <NuxtLink class="search-filter-log__nuxt-link" to="/tree/search">
@@ -237,16 +250,20 @@ onUpdated(() => {
   </div>
 
   <section>
-    <div  @click.prevent="closePopup" class="filter-tab-container none" id="filter-bg"></div>
+    <div
+      @click.prevent="closePopup"
+      class="filter-tab-container none"
+      id="filter-bg"
+    ></div>
     <div class="filter-tab-container--30 none" id="filter-bg-blur">
       <h2 class="none">정렬 선택</h2>
       <div id="filter-tab" class="filter-tab__box--30">
         <div class="filter-tab__header">
           <button
-              @click.prevent="closePopup"
-              id="filter-tab-close-btn"
-              class="filter-tab__btn--back"
-              type="button"
+            @click.prevent="closePopup"
+            id="filter-tab-close-btn"
+            class="filter-tab__btn--back"
+            type="button"
           >
             <img src="/public/svg/tab-back.svg" alt="뒤로가기 버튼" />
           </button>
@@ -257,39 +274,45 @@ onUpdated(() => {
           <div class="filter-attribute__bg">
             <h2 class="filter-attribute__title">검색 기준</h2>
             <ul id="filter-tab__list1" class="filter-tab__list1">
-              <li @click="searchFilterHandler('title')" class="filter-tab__item">
+              <li
+                @click="searchFilterHandler('title')"
+                class="filter-tab__item"
+              >
                 <label class="filter-tab__item-label">
                   <input
-                      class="filter-tab__item-radio"
-                      type="radio"
-                      name="searchFilter"
-                      value="10"
-                      checked
+                    class="filter-tab__item-radio"
+                    type="radio"
+                    name="searchFilter"
+                    value="10"
+                    checked
                   />
                   <span class="filter-tab__item--label-text">제목 검색</span>
                   <div class="filter-tab__icon-box">
                     <img
-                        class="filter-tab__icon-img"
-                        src="/svg/tab-check-btn.svg"
-                        alt="필터 버튼"
+                      class="filter-tab__icon-img"
+                      src="/svg/tab-check-btn.svg"
+                      alt="필터 버튼"
                     />
                   </div>
                 </label>
               </li>
-              <li @click="searchFilterHandler('content')" class="filter-tab__item">
+              <li
+                @click="searchFilterHandler('content')"
+                class="filter-tab__item"
+              >
                 <label class="filter-tab__item-label">
                   <input
-                      class="filter-tab__item-radio"
-                      type="radio"
-                      name="searchFilter"
-                      value="11"
+                    class="filter-tab__item-radio"
+                    type="radio"
+                    name="searchFilter"
+                    value="11"
                   />
                   <span class="filter-tab__item--label-text">내용 검색</span>
                   <div class="filter-tab__icon-box">
                     <img
-                        class="filter-tab__icon-img"
-                        src="/svg/tab-check-btn.svg"
-                        alt="필터 버튼"
+                      class="filter-tab__icon-img"
+                      src="/svg/tab-check-btn.svg"
+                      alt="필터 버튼"
                     />
                   </div>
                 </label>
@@ -297,17 +320,19 @@ onUpdated(() => {
               <li @click="searchFilterHandler('all')" class="filter-tab__item">
                 <label class="filter-tab__item-label">
                   <input
-                      class="filter-tab__item-radio"
-                      type="radio"
-                      name="searchFilter"
-                      value="12"
+                    class="filter-tab__item-radio"
+                    type="radio"
+                    name="searchFilter"
+                    value="12"
                   />
-                  <span class="filter-tab__item--label-text">제목 + 내용 검색</span>
+                  <span class="filter-tab__item--label-text"
+                    >제목 + 내용 검색</span
+                  >
                   <div class="filter-tab__icon-box">
                     <img
-                        class="filter-tab__icon-img"
-                        src="/svg/tab-check-btn.svg"
-                        alt="필터 버튼"
+                      class="filter-tab__icon-img"
+                      src="/svg/tab-check-btn.svg"
+                      alt="필터 버튼"
                     />
                   </div>
                 </label>
@@ -318,18 +343,18 @@ onUpdated(() => {
               <li @click="filterNameHandler(10)" class="filter-tab__item">
                 <label class="filter-tab__item-label">
                   <input
-                      class="filter-tab__item-radio"
-                      type="radio"
-                      name="filter"
-                      value="10"
-                      checked
+                    class="filter-tab__item-radio"
+                    type="radio"
+                    name="filter"
+                    value="10"
+                    checked
                   />
                   <span class="filter-tab__item--label-text"> 최근 수정 </span>
                   <div class="filter-tab__icon-box">
                     <img
-                        class="filter-tab__icon-img"
-                        src="/svg/tab-check-btn.svg"
-                        alt="필터 버튼"
+                      class="filter-tab__icon-img"
+                      src="/svg/tab-check-btn.svg"
+                      alt="필터 버튼"
                     />
                   </div>
                 </label>
@@ -337,17 +362,17 @@ onUpdated(() => {
               <li @click="filterNameHandler(11)" class="filter-tab__item">
                 <label class="filter-tab__item-label">
                   <input
-                      class="filter-tab__item-radio"
-                      type="radio"
-                      name="filter"
-                      value="11"
+                    class="filter-tab__item-radio"
+                    type="radio"
+                    name="filter"
+                    value="11"
                   />
                   <span class="filter-tab__item--label-text">제목</span>
                   <div class="filter-tab__icon-box">
                     <img
-                        class="filter-tab__icon-img"
-                        src="/svg/tab-check-btn.svg"
-                        alt="필터 버튼"
+                      class="filter-tab__icon-img"
+                      src="/svg/tab-check-btn.svg"
+                      alt="필터 버튼"
                     />
                   </div>
                 </label>
@@ -355,17 +380,17 @@ onUpdated(() => {
               <li @click="filterNameHandler(13)" class="filter-tab__item">
                 <label class="filter-tab__item-label">
                   <input
-                      class="filter-tab__item-radio"
-                      type="radio"
-                      name="filter"
-                      value="13"
+                    class="filter-tab__item-radio"
+                    type="radio"
+                    name="filter"
+                    value="13"
                   />
                   <span class="filter-tab__item--label-text">조회 수</span>
                   <div class="filter-tab__icon-box">
                     <img
-                        class="filter-tab__icon-img"
-                        src="/svg/tab-check-btn.svg"
-                        alt="필터 버튼"
+                      class="filter-tab__icon-img"
+                      src="/svg/tab-check-btn.svg"
+                      alt="필터 버튼"
                     />
                   </div>
                 </label>
@@ -373,17 +398,17 @@ onUpdated(() => {
               <li @click="filterNameHandler(14)" class="filter-tab__item">
                 <label class="filter-tab__item-label">
                   <input
-                      class="filter-tab__item-radio"
-                      type="radio"
-                      name="filter"
-                      value="13"
+                    class="filter-tab__item-radio"
+                    type="radio"
+                    name="filter"
+                    value="13"
                   />
                   <span class="filter-tab__item--label-text">좋아요 수</span>
                   <div class="filter-tab__icon-box">
                     <img
-                        class="filter-tab__icon-img"
-                        src="/svg/tab-check-btn.svg"
-                        alt="필터 버튼"
+                      class="filter-tab__icon-img"
+                      src="/svg/tab-check-btn.svg"
+                      alt="필터 버튼"
                     />
                   </div>
                 </label>
@@ -395,18 +420,18 @@ onUpdated(() => {
                 <li @click="sortHandler(1)" class="filter-tab__item">
                   <label class="filter-tab__item-label">
                     <input
-                        class="filter-tab__item-radio"
-                        type="radio"
-                        name="sort"
-                        value="1"
-                        checked
+                      class="filter-tab__item-radio"
+                      type="radio"
+                      name="sort"
+                      value="1"
+                      checked
                     />
                     <span class="filter-tab__item--label-text">내림차순</span>
                     <div class="filter-tab__icon-box">
                       <img
-                          class="filter-tab__icon-img"
-                          src="/svg/tab-check-btn.svg"
-                          alt="필터 버튼"
+                        class="filter-tab__icon-img"
+                        src="/svg/tab-check-btn.svg"
+                        alt="필터 버튼"
                       />
                     </div>
                   </label>
@@ -414,17 +439,17 @@ onUpdated(() => {
                 <li @click="sortHandler(0)" class="filter-tab__item">
                   <label class="filter-tab__item-label">
                     <input
-                        class="filter-tab__item-radio"
-                        type="radio"
-                        name="sort"
-                        value="0"
+                      class="filter-tab__item-radio"
+                      type="radio"
+                      name="sort"
+                      value="0"
                     />
                     <span class="filter-tab__item--label-text">오름차순</span>
                     <div class="filter-tab__icon-box">
                       <img
-                          class="filter-tab__icon-img"
-                          src="/svg/tab-check-btn.svg"
-                          alt="필터 버튼"
+                        class="filter-tab__icon-img"
+                        src="/svg/tab-check-btn.svg"
+                        alt="필터 버튼"
                       />
                     </div>
                   </label>
@@ -509,18 +534,17 @@ button {
   height: 18px;
 }
 
-
 /* 필터 */
-.search-filter-frame{
+.search-filter-frame {
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
-  .search-filter-frame-search{
-    display: flex;
-    gap: 10px;
-    align-items: center;
-  }
+.search-filter-frame-search {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
 
 .search-filter-log {
   display: flex;
@@ -601,7 +625,7 @@ button {
   margin: 0 24px;
   position: relative;
 }
-.filter-list-frame{
+.filter-list-frame {
   height: 100%;
   overflow: auto;
 }
@@ -673,7 +697,7 @@ button {
   height: 36px;
   width: 36px;
 }
-.filter-attribute__title{
+.filter-attribute__title {
   margin-left: 20px;
   margin-bottom: 8px;
   font-size: 16px;
@@ -689,16 +713,15 @@ button {
   display: block;
 }
 
-.filter-tab__list{
+.filter-tab__list {
   padding-right: 10px;
   padding-left: 10px;
   margin-bottom: 250px;
 }
-.filter-tab__list1{
+.filter-tab__list1 {
   padding-right: 10px;
   padding-left: 10px;
   border-bottom: solid 1px var(--main2--opacity40);
-margin-bottom: 20px;
+  margin-bottom: 20px;
 }
-
 </style>

--- a/frontend-2/components/input/InputBackSearchTree.vue
+++ b/frontend-2/components/input/InputBackSearchTree.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref } from "vue";
-import {value} from "lodash/seq.js";
+import { value } from "lodash/seq.js";
 //-----------------props-----------------
 const props = defineProps({
   placeholder: "",
@@ -10,13 +10,7 @@ const props = defineProps({
   page: 1,
 });
 //-----------------emit-----------------
-const emit = defineEmits([
-  "req",
-  "result",
-  "page",
-  "totalCount",
-  "totalPage",
-]);
+const emit = defineEmits(["req", "result", "page", "totalCount", "totalPage"]);
 //-----------------ref-----------------
 const result = ref([]);
 const query = ref("");
@@ -34,15 +28,18 @@ watch(page, () => {
 });
 
 // sort 값이 변경될 때 요청
-watch(() => props.sort, (newSort) => {
-  console.log(`sort changed to ${newSort}`);
+watch(
+  () => props.sort,
+  (newSort) => {
+    console.log(`sort changed to ${newSort}`);
 
-  // 페이지를 초기화하고 새로운 정렬 기준으로 요청
-  page.value = 0;
+    // 페이지를 초기화하고 새로운 정렬 기준으로 요청
+    page.value = 0;
 
-  // 새로운 sort 값으로 fetch 요청
-  createReq(newSort, page.value, filter.value, false);
-});
+    // 새로운 sort 값으로 fetch 요청
+    createReq(newSort, page.value, filter.value, false);
+  }
+);
 
 //-----------------methods-----------------
 const createReq = async (sort, currentPage, filter, isChange) => {
@@ -51,13 +48,13 @@ const createReq = async (sort, currentPage, filter, isChange) => {
     queryContent = query.value;
   }
   try {
-    const response = await $fetch(props.api, {
+    const response = await useAuthDataFetch(props.api, {
       method: "GET",
       params: {
         query: queryContent,
         sort: sort,
         page: currentPage,
-        filter : filter
+        filter: filter,
       },
     });
 
@@ -73,8 +70,9 @@ const createReq = async (sort, currentPage, filter, isChange) => {
       result.value = [...result.value, ...response.content];
 
       // 중복 제거
-      result.value = [...new Set(result.value.map(value => value.treeId))].map((treeId) =>
-          result.value.find((value) => value.treeId === treeId));
+      result.value = [
+        ...new Set(result.value.map((value) => value.treeId)),
+      ].map((treeId) => result.value.find((value) => value.treeId === treeId));
 
       // 페이지 정보 업데이트
       page.value = currentPage;
@@ -93,7 +91,6 @@ const createReq = async (sort, currentPage, filter, isChange) => {
     emit("page", page.value);
     emit("totalCount", totalCount.value);
     emit("totalPage", totalPage.value);
-
   } catch (error) {
     if (error.response && error.response.status === 400) {
       alert("검색어를 두 글자 이상 입력해 주세요.");
@@ -105,8 +102,7 @@ const createReq = async (sort, currentPage, filter, isChange) => {
 
 const dropQueryHandler = () => {
   query.value = "";
-}
-
+};
 
 //-----------------lifeCycle-----------------
 onUpdated(() => {
@@ -134,11 +130,15 @@ onUpdated(() => {
           autocomplete="off"
           @keyup.enter="createReq(sort, 0, filter, true)"
         />
-        <button @click="dropQueryHandler" class="search-bar--close" type="reset">
+        <button
+          @click="dropQueryHandler"
+          class="search-bar--close"
+          type="reset"
+        >
           <img src="/public/svg/close-button.svg" alt="close-btn" />
         </button>
       </label>
-      <button @click="createReq(sort, 0, filter,true)">
+      <button @click="createReq(sort, 0, filter, true)">
         <img src="/public/svg/lens.svg" alt="lens" />
       </button>
     </div>
@@ -146,37 +146,37 @@ onUpdated(() => {
 
   <div class="search-filter-frame">
     <div class="search-filter-log">
-    <label class="search-filter-log__checkbox-labal">
-      <input
-        class="search-filter-log__checkbox-input"
-        type="radio"
-        name="filterType"
-        value="title"
-        checked
-        v-model="filter"
-      />
-      <span class="search-filter-log__checkbox-input-text">제목</span>
-    </label>
-    <label class="search-filter-log__checkbox-labal">
-      <input
-        class="search-filter-log__checkbox-input"
-        type="radio"
-        name="filterType"
-        value="author"
-        v-model="filter"
-      />
-      <span class="search-filter-log__checkbox-input-text">저자</span>
-    </label>
-    <label class="search-filter-log__checkbox-labal">
-      <input
-        class="search-filter-log__checkbox-input"
-        type="radio"
-        name="filterType"
-        value="publisher"
-        v-model="filter"
-      />
-      <span class="search-filter-log__checkbox-input-text">출판사</span>
-    </label>
+      <label class="search-filter-log__checkbox-labal">
+        <input
+          class="search-filter-log__checkbox-input"
+          type="radio"
+          name="filterType"
+          value="title"
+          checked
+          v-model="filter"
+        />
+        <span class="search-filter-log__checkbox-input-text">제목</span>
+      </label>
+      <label class="search-filter-log__checkbox-labal">
+        <input
+          class="search-filter-log__checkbox-input"
+          type="radio"
+          name="filterType"
+          value="author"
+          v-model="filter"
+        />
+        <span class="search-filter-log__checkbox-input-text">저자</span>
+      </label>
+      <label class="search-filter-log__checkbox-labal">
+        <input
+          class="search-filter-log__checkbox-input"
+          type="radio"
+          name="filterType"
+          value="publisher"
+          v-model="filter"
+        />
+        <span class="search-filter-log__checkbox-input-text">출판사</span>
+      </label>
     </div>
     <NuxtLink class="search-filter-log__nuxt-link" to="/leaf/search">
       리프 검색 이동
@@ -255,9 +255,8 @@ button {
   height: 18px;
 }
 
-
 /* 필터 */
-.search-filter-frame{
+.search-filter-frame {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/frontend-2/components/input/InputSearchWithBackBtn.vue
+++ b/frontend-2/components/input/InputSearchWithBackBtn.vue
@@ -17,7 +17,7 @@ let filter = ref("title");
 const createReq = async (query, filter) => {
   bookResult.value = [];
   try {
-    const response = await $fetch(props.api, {
+    const response = await useAuthDataFetch(props.api, {
       method: "GET",
       params: {
         q: query,

--- a/frontend-2/components/link/SocialLogin.vue
+++ b/frontend-2/components/link/SocialLogin.vue
@@ -1,54 +1,60 @@
 <script setup>
-import {decodeCredential, googleTokenLogin} from "vue3-google-login";
-import {useMemberJoinTmp} from "~/composables/useMemberJoinTmp.js";
+import { decodeCredential, googleTokenLogin } from "vue3-google-login";
+import { useMemberJoinTmp } from "~/composables/useMemberJoinTmp.js";
 
-const memberDetail = useMemberDetail();
+const memberDetail = useMemberStore();
 const config = useRuntimeConfig();
 const joinInfo = useMemberJoinTmp();
 const router = useRouter();
 
 const googleLoginHandler = async () => {
   try {
-
     const response = await googleTokenLogin();
     const token = response.access_token;
 
-    let userInfo = await fetch(`https://www.googleapis.com/oauth2/v3/userinfo?access_token=${token}`);
+    let userInfo = await fetch(
+      `https://www.googleapis.com/oauth2/v3/userinfo?access_token=${token}`
+    );
     userInfo = await userInfo.json();
 
-    const isMember = await $fetch(`${config.public.apiBase}/auth/isMember`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({email: userInfo.email})
-    });
+    const isMember = await useAuthDataFetch(
+      `${config.public.apiBase}/auth/isMember`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email: userInfo.email }),
+      }
+    );
 
-    if (!isMember) { // 회원이 아닌 경우
-      console.log('userInfo', userInfo.email, userInfo.name, userInfo.picture);
+    if (!isMember) {
+      // 회원이 아닌 경우
+      console.log("userInfo", userInfo.email, userInfo.name, userInfo.picture);
       joinInfo.setJoinInfo(userInfo);
-      console.log('joinInfo', joinInfo);
+      console.log("joinInfo", joinInfo);
       await router.push("/member/oauth/new");
       return;
     }
 
     // 회원인 경우
-    const newTokenResponse = await $fetch(`${config.public.apiBase}/auth/newToken`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({email: userInfo.email})
-    });
+    const newTokenResponse = await useAuthDataFetch(
+      `${config.public.apiBase}/auth/newToken`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email: userInfo.email }),
+      }
+    );
 
     memberDetail.setAuthWithToken(newTokenResponse.accessToken);
-    await router.push('/home');
-
+    await router.push("/home");
   } catch (error) {
-    console.error('Google 로그인 중 오류 발생:', error);
+    console.error("Google 로그인 중 오류 발생:", error);
   }
 };
-
 </script>
 
 <template>

--- a/frontend-2/components/top-bar/TopBarTransparent.vue
+++ b/frontend-2/components/top-bar/TopBarTransparent.vue
@@ -7,7 +7,7 @@ const props = defineProps({
 const deleteResource = () => {
   // console.log(props.delete);
   if (confirm("정말 삭제하시겠습니까?")) {
-    const { data } = $fetch(props.delete, {
+    const { data } = useAuthDataFetch(props.delete, {
       baseURL: useRuntimeConfig().public.apiBase,
       method: "DELETE",
     });

--- a/frontend-2/composables/useAuthDataFetch.js
+++ b/frontend-2/composables/useAuthDataFetch.js
@@ -1,8 +1,6 @@
-import { useMemberDetail } from "./useMemberDetail";
-
-export default async function useAuthFetch(url, options = {}) {
+export default async function useAuthDataFetch(url, options = {}) {
   // 1. MemberDetail에서 token을 획득
-  const _accessToken = useMemberDetail().getAuthToken() || "";
+  const _accessToken = useMemberStore().getAuthToken() || "";
 
   // 2. 획득한 token을 헤더에 담기
   options.headers = {
@@ -11,12 +9,8 @@ export default async function useAuthFetch(url, options = {}) {
   };
 
   // 3. 사용자가 요청한 url과 option에, 획득한 token을 담아서 fetch 요청하기
-  const { data, status, error } = await useFetch(url, options);
+  const response = await $fetch(url, options);
 
   // 4. fetch의 data, error, status 등을 반환(useFetch와 유사한 형태)
-  console.log(data);
-  console.log(status);
-  console.log(error);
-
-  return { data, error, status };
+  return { response };
 }

--- a/frontend-2/composables/useAuthFetch.js
+++ b/frontend-2/composables/useAuthFetch.js
@@ -1,8 +1,6 @@
-import { useMemberDetail } from "./useMemberDetail";
-
 export default async function useAuthFetch(url, options = {}) {
   // 1. MemberDetail에서 token을 획득
-  const _accessToken = useMemberDetail().getAuthToken() || "";
+  const _accessToken = useMemberStore().getAuthToken() || "";
 
   // 2. 획득한 token을 헤더에 담기
   options.headers = {
@@ -10,16 +8,19 @@ export default async function useAuthFetch(url, options = {}) {
     Authorization: `Bearer ${_accessToken}`,
   };
 
+  options = {
+    ...options,
+    immediate: true,
+  };
+
   // 3. 사용자가 요청한 url과 option에, 획득한 token을 담아서 fetch 요청하기
-  const response = await fetch(url, options);
+  const { data, status, error, refresh } = await useFetch(url, options);
 
-  // 4. fetch의 data, error, status 등을 반환(useFetch와 유사한 형태)
-  const data = await response.json();
-  console.log(data);
-  const status = response.status;
-  console.log(status);
-  const error = !response.ok ? data : null;
-  console.log(error);
+  //4. CSR에서 한번 더 요청하도록 실행(새로고침 대비)
+  if (!import.meta.env.SSR) {
+    refresh();
+  }
 
-  return { data, error, status };
+  // 5. fetch의 data, error, status 등을 반환(useFetch와 유사한 형태)
+  return { data, error, status, refresh };
 }

--- a/frontend-2/middleware/auth.global.js
+++ b/frontend-2/middleware/auth.global.js
@@ -1,14 +1,12 @@
-import { useMemberDetail } from "#imports";
-
 export default defineNuxtRouteMiddleware((to, from) => {
-  const userDetails = useMemberDetail();
-  //to.path는 사용자가 이동하려는(요청한) 경로를 나타낸다.
-  const protectedPaths = ["/home", "/tree", "/leaf", "/memoir"];
-  if (protectedPaths.some((path) => to.path.startsWith(path))) {
-    // 로그인 여부를 확인하고 로그인하지 않은 사용자는 로그인 페이지로 이동시킨다.
-    if (userDetails.isAnonymous()) {
-      //리턴 URL을 포함시켜준다.
-      return navigateTo("/member/login?returnUrl=" + `${to.fullPath}`);
+  if (!import.meta.env.SSR) {
+    const memberStore = useMemberStore();
+    const beingLogin = !memberStore.isAnonymous();
+    const protectedPaths = ["/home", "/tree", "/leaf", "/memoir"];
+
+    if (protectedPaths.includes(to.path) && !beingLogin) {
+      return navigateTo("/member/login?returnUrl=" + to.fullPath);
     }
+    console.log("로그인 중입니다.");
   }
 });

--- a/frontend-2/pages/book/[id]/index.vue
+++ b/frontend-2/pages/book/[id]/index.vue
@@ -19,7 +19,7 @@ const {
   data: bookData,
   status: bookStatus,
   error: bookError,
-} = await useFetch(`books/${bookId}`, {
+} = await useAuthFetch(`books/${bookId}`, {
   method: "GET",
   baseURL: `${config.public.apiBase}`,
 });
@@ -34,10 +34,13 @@ const {
   data: treeCardsData,
   status: treeCardsStatus,
   error: treeCardsError,
-} = await useFetch(`trees/members/${memberId}/books/${bookId}/trees/cards`, {
-  method: "GET",
-  baseURL: `${config.public.apiBase}`,
-});
+} = await useAuthFetch(
+  `trees/members/${memberId}/books/${bookId}/trees/cards`,
+  {
+    method: "GET",
+    baseURL: `${config.public.apiBase}`,
+  }
+);
 
 if (treeCardsData.value) {
   myTreeCards.value = [...treeCardsData.value.treeBookCardResponse];
@@ -52,7 +55,7 @@ const {
   data: bookleafCradsData,
   error: bookleafCradsError,
   status: bookleafCradsStatus,
-} = await useFetch(`books/${bookId}/leaves/cards`, {
+} = await useAuthFetch(`books/${bookId}/leaves/cards`, {
   method: "GET",
   baseURL: `${config.public.apiBase}`,
 });
@@ -65,7 +68,7 @@ const {
   data: bookMemoirCradsData,
   error: bookMemoirCradsError,
   status: bookMemoirCradsStatus,
-} = await useFetch(`memoirs/books/${bookId}/memoirs/cards`, {
+} = await useAuthFetch(`memoirs/books/${bookId}/memoirs/cards`, {
   method: "GET",
   baseURL: `${config.public.apiBase}`,
 });
@@ -78,7 +81,7 @@ const {
   data: bookTreeCradsData,
   error: bookTreeCradsError,
   status: bookTreeCradsStatus,
-} = await useFetch(`trees/books/${bookId}/trees/cards`, {
+} = await useAuthFetch(`trees/books/${bookId}/trees/cards`, {
   method: "GET",
   baseURL: `${config.public.apiBase}`,
 });

--- a/frontend-2/pages/home/index.vue
+++ b/frontend-2/pages/home/index.vue
@@ -12,15 +12,17 @@ const filterTreeInfoList = ref([]);
 const seedList = ref([]);
 const seedId = ref(0);
 let observer = null;
+const memberDetail = useMemberStore();
+const { _nickname: username } = storeToRefs(memberDetail);
 
 //TODO: JWT토큰 있다면 전송하게끔 로직 수정 필요
 
-const { data: seedData, status: seedStatus } = await useFetch("seeds", {
+const { data: seedData, status: seedStatus } = await useAuthFetch("seeds", {
   baseURL: `${config.public.apiBase}`,
   method: "GET",
 });
 
-const { data: treeData, status: treeStatus } = await useAuthDataFetch(
+const { data: treeData, status: treeStatus } = await useAuthFetch(
   "trees/tree-home",
   {
     baseURL: `${config.public.apiBase}`,
@@ -30,7 +32,7 @@ const { data: treeData, status: treeStatus } = await useAuthDataFetch(
 
 const newTreeFetch = async (newSeedId) => {
   seedId.value = newSeedId;
-  const response = await $fetch("trees/tree-home-sort", {
+  const response = await useAuthDataFetch("trees/tree-home-sort", {
     baseURL: `${config.public.apiBase}`,
     method: "GET",
     params: {
@@ -117,7 +119,7 @@ const bookExRemoveNone = (selectedElement, index) => {
       <h2 class="none">나의 트리 정보</h2>
       <section class="my-tree-title-container">
         <h3>
-          <TextMainTitle :data="{ title: '나의 트리', size: 28 }" />
+          <TextMainTitle :data="{ title: `${username}님의 트리`, size: 28 }" />
         </h3>
       </section>
 

--- a/frontend-2/pages/leaf/book/[id]/edit.vue
+++ b/frontend-2/pages/leaf/book/[id]/edit.vue
@@ -1,9 +1,8 @@
 <script setup>
-
 import Editor from "@toast-ui/editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
 import { onMounted, reactive } from "vue";
-import axios, {HttpStatusCode} from "axios";
+import axios, { HttpStatusCode } from "axios";
 
 // ----------------------- Model ----------------------- //
 const config = useRuntimeConfig();
@@ -24,8 +23,7 @@ const beforeLogData = reactive({
 
 const totalPage = ref(null);
 
-const leafFormData = useState('leafFormData', () => ({
-
+const leafFormData = useState("leafFormData", () => ({
   // 페이지 번호
   startPage: undefined,
   startPageValidation: true,
@@ -50,31 +48,39 @@ const leafFormData = useState('leafFormData', () => ({
   isLoaded: false,
 }));
 
-const selectedTags = useState('selectedTags', () => ({
+const selectedTags = useState("selectedTags", () => ({
   items: [],
 }));
 
-const leafCreateUrl = useState('leafCreateUrl', () => {
+const leafCreateUrl = useState("leafCreateUrl", () => {
   return `/leaf/book/${leafId}/edit`;
 });
 
-const { data: totalPageData, status: totalPageStatus } = await useFetch(`leaves/${leafId}/book/page`, {
-  baseURL: `${config.public.apiBase}`,
-  method: "GET",
-});
+const { data: totalPageData, status: totalPageStatus } = await useAuthFetch(
+  `leaves/${leafId}/book/page`,
+  {
+    baseURL: `${config.public.apiBase}`,
+    method: "GET",
+  }
+);
 
-const { data: beforeLeafData, status: beforeLeafStatus } = await useFetch(`leaves/${leafId}/before`, {
-  baseURL: `${config.public.apiBase}`,
-  method: "GET",
-});
+const { data: beforeLeafData, status: beforeLeafStatus } = await useAuthFetch(
+  `leaves/${leafId}/before`,
+  {
+    baseURL: `${config.public.apiBase}`,
+    method: "GET",
+  }
+);
 
-const { data: leafEditData, status: leafEditStatus } = await useFetch(`/book/leaves/${leafId}/edit`, {
-  baseURL: `${config.public.apiBase}`,
-  method: "GET",
-});
+const { data: leafEditData, status: leafEditStatus } = await useAuthFetch(
+  `/book/leaves/${leafId}/edit`,
+  {
+    baseURL: `${config.public.apiBase}`,
+    method: "GET",
+  }
+);
 
 watchEffect(() => {
-
   if (totalPageStatus.value !== HttpStatusCode.Ok) {
     // console.log("totalPageData : ", totalPageData.value);
     totalPage.value = totalPageData.value;
@@ -88,7 +94,10 @@ watchEffect(() => {
     beforeLogData.tags = beforeLeafData.value.tags;
   }
 
-  if (!leafFormData.value.isLoaded && leafEditStatus.value !== HttpStatusCode.Ok) {
+  if (
+    !leafFormData.value.isLoaded &&
+    leafEditStatus.value !== HttpStatusCode.Ok
+  ) {
     // console.log("leafEditData : ", leafEditData.value);
     leafFormData.value.startPage = leafEditData.value.startPage;
     leafFormData.value.endPage = leafEditData.value.endPage;
@@ -130,10 +139,13 @@ onMounted(() => {
           treeFormData.append("image", blob);
 
           // MemoirFileApiController - uploadEditorImage 메서드 호출
-          const response = await fetch(`${config.public.apiBase}/leaf/image-upload`, {
-            method: "POST",
-            body: treeFormData,
-          });
+          const response = await fetch(
+            `${config.public.apiBase}/leaf/image-upload`,
+            {
+              method: "POST",
+              body: treeFormData,
+            }
+          );
           // 컨트롤러에서 전달받은 디스크에 저장된 파일 명
           const filename = await response.text();
           // console.log("서버에 저장된 파일 명 : ", filename);
@@ -188,13 +200,17 @@ const pageValidation = () => {
 
 const tagDrop = (tag) => {
   // console.log("tagDrop : ", tag);
-  selectedTags.value.items = selectedTags.value.items.filter((item) => item.id !== tag.id);
+  selectedTags.value.items = selectedTags.value.items.filter(
+    (item) => item.id !== tag.id
+  );
   leafFormData.value.tagIds = selectedTags.value.items.map((tag) => tag.id);
 };
 
 const validate = () => {
-
-  if (!leafFormData.value.startPage || !leafFormData.value.startPageValidation) {
+  if (
+    !leafFormData.value.startPage ||
+    !leafFormData.value.startPageValidation
+  ) {
     leafFormData.value.startPageValidation = false;
     alert("시작 페이지를 잘못 입력하셨습니다.");
     return false;
@@ -216,13 +232,15 @@ const validate = () => {
 };
 
 const submitHandler = async () => {
-
   if (!validate()) {
     return;
   }
 
   // console.log("leafFormData POST > : ", leafFormData.value);
-  const response = await axios.put(`${config.public.apiBase}/book/leaves/${leafId}`, leafFormData.value);
+  const response = await axios.put(
+    `${config.public.apiBase}/book/leaves/${leafId}`,
+    leafFormData.value
+  );
 
   if (response.status !== HttpStatusCode.Ok) {
     throw new Error("Network response was not ok");
@@ -235,7 +253,6 @@ const submitHandler = async () => {
 
 const dataInit = () => {
   leafFormData.value = {
-
     // 페이지 번호
     startPage: undefined,
     startPageValidation: true,
@@ -260,7 +277,6 @@ const dataInit = () => {
     isLoaded: false,
   };
 };
-
 </script>
 
 <template>
@@ -268,7 +284,10 @@ const dataInit = () => {
     <h1 class="none">리프 수정 페이지</h1>
     <section class="tob-bar-back-container">
       <h1 class="none">리프 수정 상단 바</h1>
-      <TopBarBack title="리프 수정" :link="`/leaf?leafId=${leafId}`"></TopBarBack>
+      <TopBarBack
+        title="리프 수정"
+        :link="`/leaf?leafId=${leafId}`"
+      ></TopBarBack>
     </section>
   </header>
 
@@ -295,34 +314,37 @@ const dataInit = () => {
         <section class="first-log_page-input-container">
           <h1 class="none">리프 페이지</h1>
           <InputPageNumber
-              :data="{
-                startPage: leafFormData.startPage,
-                endPage: leafFormData.endPage,
-                maxPage: totalPage,
-              }"
-              @startPage="inputStartPage"
-              @endPage="inputEndPage"
+            :data="{
+              startPage: leafFormData.startPage,
+              endPage: leafFormData.endPage,
+              maxPage: totalPage,
+            }"
+            @startPage="inputStartPage"
+            @endPage="inputEndPage"
           >
           </InputPageNumber>
         </section>
 
         <section class="input-form__select-tag-input-container">
           <h1 class="none">리프 태그 입력</h1>
-          <InputTagSelect :selectedTag="selectedTags.items" @drop="tagDrop"></InputTagSelect>
+          <InputTagSelect
+            :selectedTag="selectedTags.items"
+            @drop="tagDrop"
+          ></InputTagSelect>
         </section>
 
         <section class="input-form__input-container">
           <h1 class="none">로그이름 입력</h1>
           <InputTextBox
-              :data="{
-                label: '*제목',
-                name: 'title',
-                placeholder: '리프 제목을 입력해 주세요.',
-                value: leafFormData.title,
-                validate: leafFormData.titleValidation,
-                validateMessage: '리프 제목을 입력해 주세요.'
-              }"
-              @inputData="inputTitle"
+            :data="{
+              label: '*제목',
+              name: 'title',
+              placeholder: '리프 제목을 입력해 주세요.',
+              value: leafFormData.title,
+              validate: leafFormData.titleValidation,
+              validateMessage: '리프 제목을 입력해 주세요.',
+            }"
+            @inputData="inputTitle"
           ></InputTextBox>
         </section>
 
@@ -341,12 +363,17 @@ const dataInit = () => {
 
         <section class="input-form__input-container">
           <h1 class="none">공개성 선택</h1>
-          <InputVisibility v-model:visibility="leafFormData.visibility"></InputVisibility>
+          <InputVisibility
+            v-model:visibility="leafFormData.visibility"
+          ></InputVisibility>
         </section>
 
         <section class="book-tree-submit-container">
           <h1 class="none">리프 수정 버튼</h1>
-          <ButtonSubmitBtnFullBar text="리프 수정" @submit="submitHandler"></ButtonSubmitBtnFullBar>
+          <ButtonSubmitBtnFullBar
+            text="리프 수정"
+            @submit="submitHandler"
+          ></ButtonSubmitBtnFullBar>
         </section>
       </section>
     </form>

--- a/frontend-2/pages/leaf/book/[id]/index.vue
+++ b/frontend-2/pages/leaf/book/[id]/index.vue
@@ -1,8 +1,7 @@
 <script setup>
-
 import { ref } from "vue";
 import "@toast-ui/editor/dist/toastui-editor.css";
-import Viewer from '@toast-ui/editor/dist/toastui-editor-viewer';
+import Viewer from "@toast-ui/editor/dist/toastui-editor-viewer";
 import CardHiddenInfo from "~/components/card/CardHiddenInfo.vue";
 import CardTreeInfoCover from "~/components/card/CardTreeInfoCover.vue";
 
@@ -14,19 +13,19 @@ const leafId = route.params.id;
 
 // ---------------------- Model ---------------------- //
 let cardHiddenInfo = reactive({
-  hiddenText: '자세히',
-  authors: '작가 이름',
-  translators: '번역가 이름',
-  publisher: '출판사 이름',
+  hiddenText: "자세히",
+  authors: "작가 이름",
+  translators: "번역가 이름",
+  publisher: "출판사 이름",
   page: 100, // 총 페이지 수
   seed: 1,
-  treeDescription: '트리 설명글',
+  treeDescription: "트리 설명글",
   readPage: 50, // 읽은 페이지 수
   progress: 50, // 읽은 페이지 수 / 총 페이지 수
   fullPage: 100, // 총 페이지 수
   leaf: 100, // 리프 수
   like: 100, // 리프 수
-  view: 100 // 리프 수
+  view: 100, // 리프 수
 });
 
 const editor = ref({
@@ -36,19 +35,19 @@ const editor = ref({
 });
 
 const leafPageInfo = reactive({
-  title: '내용',
+  title: "내용",
   size: 28,
   startPage: 100,
-  endPage: 200
+  endPage: 200,
 });
 
 const member = ref({
   id: 1,
-  nickName: '닉네임',
-  userName: '유저이름',
-  email: '이메일',
-  backImgName: '배경이미지',
-  profileImgName: '프로필이미지',
+  nickName: "닉네임",
+  userName: "유저이름",
+  email: "이메일",
+  backImgName: "배경이미지",
+  profileImgName: "프로필이미지",
 });
 
 const info = reactive({});
@@ -59,38 +58,50 @@ const memoirItems = ref([]);
 const leafItems = ref([]);
 
 // ----------------------  API ---------------------- //
-const { data: infoData, error: infoError }
-    = await useFetch(() => `trees/leaves/${leafId}/info`, {
+const { data: infoData, error: infoError } = await useAuthFetch(
+  () => `trees/leaves/${leafId}/info`,
+  {
     baseURL: config.public.apiBase,
-});
+  }
+);
 
-const { data: leafDetailData, error: leafDetailDataError }
-    = await useFetch(() => `leaves/${leafId}`, {
+const { data: leafDetailData, error: leafDetailDataError } = await useAuthFetch(
+  () => `leaves/${leafId}`,
+  {
     baseURL: config.public.apiBase,
-});
+  }
+);
 
-const { data: leafMemberInfo, error: leafMemberInfoError }
-    = await useFetch(() => `leaves/${leafId}/member`, {
+const { data: leafMemberInfo, error: leafMemberInfoError } = await useAuthFetch(
+  () => `leaves/${leafId}/member`,
+  {
     baseURL: config.public.apiBase,
-});
+  }
+);
 
-const { data: leafCardData, error: leafCardError }
-    = await useFetch(() => `/members/${member.value.id}/leaves/book/cards`, {
+const { data: leafCardData, error: leafCardError } = await useAuthFetch(
+  () => `/members/${member.value.id}/leaves/book/cards`,
+  {
     method: "GET",
     baseURL: `${config.public.apiBase}`,
-});
+  }
+);
 
-const { data: treeCardData, error: treeCardError }
-    = await useFetch(() => `trees/members/${member.value.id}/trees/book/cards`, {
+const { data: treeCardData, error: treeCardError } = await useAuthFetch(
+  () => `trees/members/${member.value.id}/trees/book/cards`,
+  {
     method: "GET",
     baseURL: `${config.public.apiBase}`,
-});
+  }
+);
 
-const { data: memoirCardData, error: memoirCardError }
-    = await useFetch(() => `memoirs/members/${member.value.id}/memoirs/book/cards`, {
+const { data: memoirCardData, error: memoirCardError } = await useAuthFetch(
+  () => `memoirs/members/${member.value.id}/memoirs/book/cards`,
+  {
     method: "GET",
     baseURL: `${config.public.apiBase}`,
-});
+  }
+);
 
 if (leafCardData.value) {
   console.log(leafCardData.value);
@@ -109,12 +120,12 @@ if (memoirCardData.value) {
 
 watchEffect(() => {
   if (infoData.value) {
-    console.log('infoData.value', infoData.value);
+    console.log("infoData.value", infoData.value);
     Object.assign(info, infoData.value);
   }
 
   if (leafDetailData.value) {
-    console.log('leafDetailData.value', leafDetailData.value);
+    console.log("leafDetailData.value", leafDetailData.value);
     editor.value.title = leafDetailData.value.leafTitle;
     editor.value.text = leafDetailData.value.leafContent;
     leafPageInfo.startPage = leafDetailData.value.startPage;
@@ -136,25 +147,23 @@ onMounted(() => {
   const viewer = new Viewer({
     el: document.querySelector("#viewer"),
     height: "500px",
-    initialValue: "hello"
+    initialValue: "hello",
   });
   viewer.setMarkdown(editor.value.text);
 });
-
 </script>
 
 <template>
-
   <Title>리프 정보</Title>
 
   <header>
     <BackgroundDetail
-        :edit="`/leaf/book/${leafId}/edit`"
-        :backImgPath="coverImageName"
-        :username="member.nickName"
-        :userid="member.email"
-        :memoirTitle="leafDetailData.leafTitle"
-        :userUrl="`/member/${member.id}`"
+      :edit="`/leaf/book/${leafId}/edit`"
+      :backImgPath="coverImageName"
+      :username="member.nickName"
+      :userid="member.email"
+      :memoirTitle="leafDetailData.leafTitle"
+      :userUrl="`/member/${member.id}`"
     />
   </header>
 
@@ -165,12 +174,12 @@ onMounted(() => {
     </section>
     <section class="branch-tree-detail-container">
       <h2 class="none">트리 상세 설명</h2>
-      <CardHiddenInfo :data ="info" >트리 상세 설명</CardHiddenInfo>
+      <CardHiddenInfo :data="info">트리 상세 설명</CardHiddenInfo>
     </section>
 
     <section class="leaf-page-info-container">
       <h2 class="none">도서 읽은 정보</h2>
-      <BarLeafReadingPageInfo :data="leafPageInfo" ></BarLeafReadingPageInfo>
+      <BarLeafReadingPageInfo :data="leafPageInfo"></BarLeafReadingPageInfo>
     </section>
 
     <!-- 에디터 뷰어 -->
@@ -182,10 +191,10 @@ onMounted(() => {
     <!-- 팔로우 -->
     <section class="follow-container">
       <BarUserInfoFollowBtn
-          :followId="member.id"
-          :userImg="member.profileImgName"
-          :username="member.userName"
-          :userid="member.email"
+        :followId="member.id"
+        :userImg="member.profileImgName"
+        :username="member.userName"
+        :userid="member.email"
       />
     </section>
 
@@ -196,12 +205,12 @@ onMounted(() => {
       <!-- 컴포넌트 -->
       <section class="user-another-records-title-container">
         <TextMainTitle
-            :data="{ title: `${member.nickName}의 다른 최근 기록들`, size: 28 }"
+          :data="{ title: `${member.nickName}의 다른 최근 기록들`, size: 28 }"
         />
       </section>
       <section
-          v-if="treeItems.length > 0"
-          class="branch-tree-other-recode-sub-title-container"
+        v-if="treeItems.length > 0"
+        class="branch-tree-other-recode-sub-title-container"
       >
         <TextMainTitle :data="{ title: `🌲 트리`, size: 24 }" />
       </section>
@@ -211,8 +220,8 @@ onMounted(() => {
       </section>
 
       <section
-          v-if="memoirItems.length > 0"
-          class="branch-tree-other-recode-sub-title-container"
+        v-if="memoirItems.length > 0"
+        class="branch-tree-other-recode-sub-title-container"
       >
         <TextMainTitle :data="{ title: `📖 회고록`, size: 24 }" />
       </section>
@@ -225,8 +234,8 @@ onMounted(() => {
       </section>
 
       <section
-          v-if="leafItems.length > 0"
-          class="branch-tree-other-recode-sub-title-container"
+        v-if="leafItems.length > 0"
+        class="branch-tree-other-recode-sub-title-container"
       >
         <TextMainTitle :data="{ title: `🌿 리프`, size: 24 }" />
       </section>
@@ -236,7 +245,6 @@ onMounted(() => {
         <CardAnotherRecordsList :items="leafItems" />
       </section>
     </section>
-
   </main>
 
   <Footer :noticeText="`개발 중입니다.`" />
@@ -252,7 +260,6 @@ onMounted(() => {
       <NavNavigationBar :active="'home'" />
     </section>
   </aside>
-
 </template>
 
 <style scoped>

--- a/frontend-2/pages/leaf/book/[id]/new.vue
+++ b/frontend-2/pages/leaf/book/[id]/new.vue
@@ -1,9 +1,8 @@
 <script setup>
-
 import Editor from "@toast-ui/editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
 import { onMounted, reactive, watch } from "vue";
-import axios, {HttpStatusCode} from "axios";
+import axios, { HttpStatusCode } from "axios";
 
 // ----------------------- Model ----------------------- //
 const config = useRuntimeConfig();
@@ -24,8 +23,7 @@ const beforeLogData = reactive({
 
 const totalPage = ref(null);
 
-const leafFormData = useState('leafFormData', () => ({
-
+const leafFormData = useState("leafFormData", () => ({
   // 페이지 번호
   startPage: undefined,
   startPageValidation: true,
@@ -47,26 +45,31 @@ const leafFormData = useState('leafFormData', () => ({
   visibility: true,
 }));
 
-const selectedTags = useState('selectedTags', () => ({
+const selectedTags = useState("selectedTags", () => ({
   items: [],
 }));
 
-const leafCreateUrl = useState('leafCreateUrl', () => {
+const leafCreateUrl = useState("leafCreateUrl", () => {
   return `/leaf/book/${parentLeafId}/new`;
 });
 
-const { data: totalPageData, status: totalPageStatus } = await useFetch(`leaves/${parentLeafId}/book/page`, {
-  baseURL: `${config.public.apiBase}`,
-  method: "GET",
-});
+const { data: totalPageData, status: totalPageStatus } = await useAuthFetch(
+  `leaves/${parentLeafId}/book/page`,
+  {
+    baseURL: `${config.public.apiBase}`,
+    method: "GET",
+  }
+);
 
-const { data: beforeLeafData, status: beforeLeafStatus } = await useFetch(`leaves/${parentLeafId}/before`, {
-  baseURL: `${config.public.apiBase}`,
-  method: "GET",
-});
+const { data: beforeLeafData, status: beforeLeafStatus } = await useAuthFetch(
+  `leaves/${parentLeafId}/before`,
+  {
+    baseURL: `${config.public.apiBase}`,
+    method: "GET",
+  }
+);
 
 watchEffect(() => {
-
   if (totalPageStatus.value !== HttpStatusCode.Ok) {
     // console.log("totalPageData : ", totalPageData.value);
     totalPage.value = totalPageData.value;
@@ -114,10 +117,13 @@ onMounted(() => {
           treeFormData.append("image", blob);
 
           // MemoirFileApiController - uploadEditorImage 메서드 호출
-          const response = await fetch(`${config.public.apiBase}/leaf/image-upload`, {
-            method: "POST",
-            body: treeFormData,
-          });
+          const response = await fetch(
+            `${config.public.apiBase}/leaf/image-upload`,
+            {
+              method: "POST",
+              body: treeFormData,
+            }
+          );
           // 컨트롤러에서 전달받은 디스크에 저장된 파일 명
           const filename = await response.text();
           // console.log("서버에 저장된 파일 명 : ", filename);
@@ -172,13 +178,17 @@ const pageValidation = () => {
 
 const tagDrop = (tag) => {
   // console.log("tagDrop : ", tag);
-  selectedTags.value.items = selectedTags.value.items.filter((item) => item.id !== tag.id);
+  selectedTags.value.items = selectedTags.value.items.filter(
+    (item) => item.id !== tag.id
+  );
   leafFormData.value.tagIds = selectedTags.value.items.map((tag) => tag.id);
 };
 
 const validate = () => {
-
-  if (!leafFormData.value.startPage || !leafFormData.value.startPageValidation) {
+  if (
+    !leafFormData.value.startPage ||
+    !leafFormData.value.startPageValidation
+  ) {
     leafFormData.value.startPageValidation = false;
     alert("시작 페이지를 잘못 입력하셨습니다.");
     return false;
@@ -200,13 +210,15 @@ const validate = () => {
 };
 
 const submitHandler = async () => {
-
   if (!validate()) {
     return;
   }
 
   // console.log("leafFormData POST > : ", leafFormData.value);
-  const response = await axios.post(`${config.public.apiBase}/book/leaves/${parentLeafId}`, leafFormData.value);
+  const response = await axios.post(
+    `${config.public.apiBase}/book/leaves/${parentLeafId}`,
+    leafFormData.value
+  );
 
   if (response.status !== HttpStatusCode.Created) {
     throw new Error("Network response was not ok");
@@ -219,7 +231,6 @@ const submitHandler = async () => {
 
   router.push(`/leaf/?leafId=${leafId}`);
 };
-
 </script>
 
 <template>
@@ -227,7 +238,10 @@ const submitHandler = async () => {
     <h1 class="none">리프 생성 페이지</h1>
     <section class="tob-bar-back-container">
       <h1 class="none">리프 생성 상단 바</h1>
-      <TopBarBack title="리프 생성" :link="`/leaf?leafId=${parentLeafId}`"></TopBarBack>
+      <TopBarBack
+        title="리프 생성"
+        :link="`/leaf?leafId=${parentLeafId}`"
+      ></TopBarBack>
     </section>
   </header>
 
@@ -254,34 +268,37 @@ const submitHandler = async () => {
         <section class="first-log_page-input-container">
           <h1 class="none">리프 페이지</h1>
           <InputPageNumber
-              :data="{
-                startPage: leafFormData.startPage,
-                endPage: leafFormData.endPage,
-                maxPage: totalPage,
-              }"
-              @startPage="inputStartPage"
-              @endPage="inputEndPage"
+            :data="{
+              startPage: leafFormData.startPage,
+              endPage: leafFormData.endPage,
+              maxPage: totalPage,
+            }"
+            @startPage="inputStartPage"
+            @endPage="inputEndPage"
           >
           </InputPageNumber>
         </section>
 
         <section class="input-form__select-tag-input-container">
           <h1 class="none">리프 태그 입력</h1>
-          <InputTagSelect :selectedTag="selectedTags.items" @drop="tagDrop"></InputTagSelect>
+          <InputTagSelect
+            :selectedTag="selectedTags.items"
+            @drop="tagDrop"
+          ></InputTagSelect>
         </section>
 
         <section class="input-form__input-container">
           <h1 class="none">로그이름 입력</h1>
           <InputTextBox
-              :data="{
-                label: '*제목',
-                name: 'title',
-                placeholder: '리프 제목을 입력해 주세요.',
-                value: leafFormData.title,
-                validate: leafFormData.titleValidation,
-                validateMessage: '리프 제목을 입력해 주세요.'
-              }"
-              @inputData="inputTitle"
+            :data="{
+              label: '*제목',
+              name: 'title',
+              placeholder: '리프 제목을 입력해 주세요.',
+              value: leafFormData.title,
+              validate: leafFormData.titleValidation,
+              validateMessage: '리프 제목을 입력해 주세요.',
+            }"
+            @inputData="inputTitle"
           ></InputTextBox>
         </section>
 
@@ -300,12 +317,17 @@ const submitHandler = async () => {
 
         <section class="input-form__input-container">
           <h1 class="none">공개성 선택</h1>
-          <InputVisibility v-model:visibility="leafFormData.visibility"></InputVisibility>
+          <InputVisibility
+            v-model:visibility="leafFormData.visibility"
+          ></InputVisibility>
         </section>
 
         <section class="book-tree-submit-container">
           <h1 class="none">리프 생성 버튼</h1>
-          <ButtonSubmitBtnFullBar text="리프 생성" @submit="submitHandler"></ButtonSubmitBtnFullBar>
+          <ButtonSubmitBtnFullBar
+            text="리프 생성"
+            @submit="submitHandler"
+          ></ButtonSubmitBtnFullBar>
         </section>
       </section>
     </form>

--- a/frontend-2/pages/leaf/etc/[id]/edit.vue
+++ b/frontend-2/pages/leaf/etc/[id]/edit.vue
@@ -1,9 +1,8 @@
 <script setup>
-
 import Editor from "@toast-ui/editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
 import { onMounted, reactive } from "vue";
-import axios, {HttpStatusCode} from "axios";
+import axios, { HttpStatusCode } from "axios";
 
 // ----------------------- Model ----------------------- //
 const config = useRuntimeConfig();
@@ -22,8 +21,7 @@ const beforeLogData = reactive({
   ],
 });
 
-const leafFormData = useState('leafFormData', () => ({
-
+const leafFormData = useState("leafFormData", () => ({
   // 태그 데이터
   tagIds: [],
   tagSelected: true,
@@ -42,26 +40,31 @@ const leafFormData = useState('leafFormData', () => ({
   isLoaded: false,
 }));
 
-const selectedTags = useState('selectedTags', () => ({
+const selectedTags = useState("selectedTags", () => ({
   items: [],
 }));
 
-const leafCreateUrl = useState('leafCreateUrl', () => {
+const leafCreateUrl = useState("leafCreateUrl", () => {
   return `/leaf/etc/${leafId}/edit`;
 });
 
-const { data: beforeLeafData, status: beforeLeafStatus } = await useFetch(`leaves/${leafId}/before`, {
-  baseURL: `${config.public.apiBase}`,
-  method: "GET",
-});
+const { data: beforeLeafData, status: beforeLeafStatus } = await useAuthFetch(
+  `leaves/${leafId}/before`,
+  {
+    baseURL: `${config.public.apiBase}`,
+    method: "GET",
+  }
+);
 
-const { data: leafData, status: leafStatus } = await useFetch(`etc/leaves/${leafId}/edit`, {
-  baseURL: `${config.public.apiBase}`,
-  method: "GET",
-});
+const { data: leafData, status: leafStatus } = await useAuthFetch(
+  `etc/leaves/${leafId}/edit`,
+  {
+    baseURL: `${config.public.apiBase}`,
+    method: "GET",
+  }
+);
 
 watchEffect(() => {
-
   if (beforeLeafStatus.value !== HttpStatusCode.Ok) {
     // console.log("beforeLeafData : ", beforeLeafData.value);
     beforeLogData.id = beforeLeafData.value.id;
@@ -79,7 +82,8 @@ watchEffect(() => {
     leafFormData.value.isLoaded = true;
   }
 
-  if (selectedTags.value.items) { // 리프 태그 데이터 적용
+  if (selectedTags.value.items) {
+    // 리프 태그 데이터 적용
     leafFormData.value.tagIds = selectedTags.value.items.map((tag) => tag.id);
   }
 
@@ -113,10 +117,13 @@ onMounted(() => {
           treeFormData.append("image", blob);
 
           // MemoirFileApiController - uploadEditorImage 메서드 호출
-          const response = await fetch(`${config.public.apiBase}/leaf/image-upload`, {
-            method: "POST",
-            body: treeFormData,
-          });
+          const response = await fetch(
+            `${config.public.apiBase}/leaf/image-upload`,
+            {
+              method: "POST",
+              body: treeFormData,
+            }
+          );
           // 컨트롤러에서 전달받은 디스크에 저장된 파일 명
           const filename = await response.text();
           // console.log("서버에 저장된 파일 명 : ", filename);
@@ -148,12 +155,13 @@ const inputTitle = (title) => {
 };
 
 const tagDrop = (tag) => {
-  selectedTags.value.items = selectedTags.value.items.filter((item) => item.id !== tag.id);
+  selectedTags.value.items = selectedTags.value.items.filter(
+    (item) => item.id !== tag.id
+  );
   leafFormData.value.tagIds = selectedTags.value.items.map((tag) => tag.id);
 };
 
 const validate = () => {
-
   if (!leafFormData.value.title) {
     leafFormData.value.titleValidation = false;
     alert("리프 제목을 입력해 주세요.");
@@ -164,13 +172,15 @@ const validate = () => {
 };
 
 const submitHandler = async () => {
-
   if (!validate()) {
     return;
   }
 
   // console.log("leafFormData POST > : ", leafFormData.value);
-  const response = await axios.put(`${config.public.apiBase}/etc/leaves/${leafId}`, leafFormData.value);
+  const response = await axios.put(
+    `${config.public.apiBase}/etc/leaves/${leafId}`,
+    leafFormData.value
+  );
 
   if (response.status !== HttpStatusCode.Ok) {
     throw new Error("Network response was not ok");
@@ -184,7 +194,6 @@ const submitHandler = async () => {
   selectedTags.value.items = [];
   router.push(`/leaf/?leafId=${leafId}`);
 };
-
 </script>
 
 <template>
@@ -192,7 +201,10 @@ const submitHandler = async () => {
     <h1 class="none">리프 수정 페이지</h1>
     <section class="tob-bar-back-container">
       <h1 class="none">리프 수정 상단 바</h1>
-      <TopBarBack title="리프 수정" :link="`/leaf?leafId=${leafId}`"></TopBarBack>
+      <TopBarBack
+        title="리프 수정"
+        :link="`/leaf?leafId=${leafId}`"
+      ></TopBarBack>
     </section>
   </header>
 
@@ -219,21 +231,24 @@ const submitHandler = async () => {
         <section class="etc-input-title-container">
           <h1 class="none">로그이름 입력</h1>
           <InputTextBox
-              :data="{
-                label: '*제목',
-                name: 'title',
-                placeholder: '리프 제목을 입력해 주세요.',
-                value: leafFormData.title,
-                validate: leafFormData.titleValidation,
-                validateMessage: '리프 제목을 입력해 주세요.'
-              }"
-              @inputData="inputTitle"
+            :data="{
+              label: '*제목',
+              name: 'title',
+              placeholder: '리프 제목을 입력해 주세요.',
+              value: leafFormData.title,
+              validate: leafFormData.titleValidation,
+              validateMessage: '리프 제목을 입력해 주세요.',
+            }"
+            @inputData="inputTitle"
           ></InputTextBox>
         </section>
 
         <section class="input-form__select-tag-input-container">
           <h1 class="none">리프 태그 입력</h1>
-          <InputTagSelect :selectedTag="selectedTags.items" @drop="tagDrop"></InputTagSelect>
+          <InputTagSelect
+            :selectedTag="selectedTags.items"
+            @drop="tagDrop"
+          ></InputTagSelect>
         </section>
 
         <section class="book-tree-input-form__large-input-container">
@@ -251,12 +266,17 @@ const submitHandler = async () => {
 
         <section class="input-form__input-container">
           <h1 class="none">공개성 선택</h1>
-          <InputVisibility v-model:visibility="leafFormData.visibility"></InputVisibility>
+          <InputVisibility
+            v-model:visibility="leafFormData.visibility"
+          ></InputVisibility>
         </section>
 
         <section class="book-tree-submit-container">
           <h1 class="none">리프 수정 버튼</h1>
-          <ButtonSubmitBtnFullBar text="리프 수정" @submit="submitHandler"></ButtonSubmitBtnFullBar>
+          <ButtonSubmitBtnFullBar
+            text="리프 수정"
+            @submit="submitHandler"
+          ></ButtonSubmitBtnFullBar>
         </section>
       </section>
     </form>
@@ -277,5 +297,4 @@ const submitHandler = async () => {
 .etc-input-title-container {
   margin: 40px 24px;
 }
-
 </style>

--- a/frontend-2/pages/leaf/etc/[id]/index.vue
+++ b/frontend-2/pages/leaf/etc/[id]/index.vue
@@ -1,8 +1,7 @@
 <script setup>
-
 import { ref } from "vue";
 import "@toast-ui/editor/dist/toastui-editor.css";
-import Viewer from '@toast-ui/editor/dist/toastui-editor-viewer';
+import Viewer from "@toast-ui/editor/dist/toastui-editor-viewer";
 
 const coverImageName = ref("background-image.png");
 const myProfile = ref("/jpg/leaf-profile.jpg");
@@ -12,19 +11,19 @@ const leafId = route.params.id;
 
 // ---------------------- Model ---------------------- //
 let cardHiddenInfo = reactive({
-  hiddenText: '자세히',
-  authors: '작가 이름',
-  translators: '번역가 이름',
-  publisher: '출판사 이름',
+  hiddenText: "자세히",
+  authors: "작가 이름",
+  translators: "번역가 이름",
+  publisher: "출판사 이름",
   page: 100, // 총 페이지 수
   seed: 1,
-  treeDescription: '트리 설명글',
+  treeDescription: "트리 설명글",
   readPage: 50, // 읽은 페이지 수
   progress: 50, // 읽은 페이지 수 / 총 페이지 수
   fullPage: 100, // 총 페이지 수
   leaf: 100, // 리프 수
   like: 100, // 리프 수
-  view: 100 // 리프 수
+  view: 100, // 리프 수
 });
 
 const editor = ref({
@@ -34,44 +33,53 @@ const editor = ref({
 });
 
 const leafPageInfo = reactive({
-  title: '내용',
+  title: "내용",
   size: 28,
   startPage: 100,
-  endPage: 200
+  endPage: 200,
 });
 
 const leafMember = reactive({
   id: 1,
-  nickName: '닉네임',
-  userName: '유저이름',
-  email: '이메일',
-  backImgName: '배경이미지',
-  profileImgName: '프로필이미지',
+  nickName: "닉네임",
+  userName: "유저이름",
+  email: "이메일",
+  backImgName: "배경이미지",
+  profileImgName: "프로필이미지",
 });
 
 let info = reactive({});
 
 // ----------------------  API ---------------------- //
-const { data: infoData, error: infoError } = await useFetch(() => `trees/leaves/${leafId}/info`, {
-  baseURL: config.public.apiBase,
-});
+const { data: infoData, error: infoError } = await useAuthFetch(
+  () => `trees/leaves/${leafId}/info`,
+  {
+    baseURL: config.public.apiBase,
+  }
+);
 
-const { data: leafDetailData, error: leafDetailDataError } = await useFetch(() => `leaves/${leafId}`, {
-  baseURL: config.public.apiBase,
-});
+const { data: leafDetailData, error: leafDetailDataError } = await useAuthFetch(
+  () => `leaves/${leafId}`,
+  {
+    baseURL: config.public.apiBase,
+  }
+);
 
-const { data: leafMemberInfo, error: leafMemberInfoError } = await useFetch(() => `leaves/${leafId}/member`, {
-  baseURL: config.public.apiBase,
-});
+const { data: leafMemberInfo, error: leafMemberInfoError } = await useAuthFetch(
+  () => `leaves/${leafId}/member`,
+  {
+    baseURL: config.public.apiBase,
+  }
+);
 
 watchEffect(() => {
   if (infoData.value) {
-    console.log('infoData.value', infoData.value);
+    console.log("infoData.value", infoData.value);
     Object.assign(info, infoData.value);
   }
 
   if (leafDetailData.value) {
-    console.log('leafDetailData.value', leafDetailData.value);
+    console.log("leafDetailData.value", leafDetailData.value);
     editor.value.title = leafDetailData.value.leafTitle;
     editor.value.text = leafDetailData.value.leafContent;
     leafPageInfo.startPage = leafDetailData.value.startPage;
@@ -93,30 +101,27 @@ onMounted(() => {
   const viewer = new Viewer({
     el: document.querySelector("#viewer"),
     height: "500px",
-    initialValue: "hello"
+    initialValue: "hello",
   });
   viewer.setMarkdown(editor.value.text);
 });
-
 </script>
 
 <template>
-
   <Title>리프 정보</Title>
 
   <header>
     <BackgroundDetail
-        :edit="`/leaf/etc/${leafId}/edit`"
-        :backImgPath="coverImageName"
-        :username="leafMember.nickName"
-        :userid="leafMember.email"
-        :memoirTitle="leafDetailData.leafTitle"
-        :userUrl="`/member/${leafMember.id}`"
+      :edit="`/leaf/etc/${leafId}/edit`"
+      :backImgPath="coverImageName"
+      :username="leafMember.nickName"
+      :userid="leafMember.email"
+      :memoirTitle="leafDetailData.leafTitle"
+      :userUrl="`/member/${leafMember.id}`"
     />
   </header>
 
   <main>
-
     <section class="leaf-page-info-container">
       <h2 class="none">제목</h2>
       <text-main-title :data="{ title: '내용', size: 28 }"></text-main-title>
@@ -131,10 +136,10 @@ onMounted(() => {
     <!-- 팔로우 -->
     <section class="follow-container">
       <BarUserInfoFollowBtn
-          :followId="leafMember.id"
-          :userImg="leafMember.profileImgName"
-          :username="leafMember.userName"
-          :userid="leafMember.email"
+        :followId="leafMember.id"
+        :userImg="leafMember.profileImgName"
+        :username="leafMember.userName"
+        :userid="leafMember.email"
       />
     </section>
 
@@ -145,12 +150,12 @@ onMounted(() => {
       <!-- 컴포넌트 -->
       <section class="user-another-records-title-container">
         <TextMainTitle
-            :data="{ title: `${member.nickName}의 다른 최근 기록들`, size: 28 }"
+          :data="{ title: `${member.nickName}의 다른 최근 기록들`, size: 28 }"
         />
       </section>
       <section
-          v-if="treeItems.length > 0"
-          class="branch-tree-other-recode-sub-title-container"
+        v-if="treeItems.length > 0"
+        class="branch-tree-other-recode-sub-title-container"
       >
         <TextMainTitle :data="{ title: `🌲 트리`, size: 24 }" />
       </section>
@@ -160,8 +165,8 @@ onMounted(() => {
       </section>
 
       <section
-          v-if="memoirItems.length > 0"
-          class="branch-tree-other-recode-sub-title-container"
+        v-if="memoirItems.length > 0"
+        class="branch-tree-other-recode-sub-title-container"
       >
         <TextMainTitle :data="{ title: `📖 회고록`, size: 24 }" />
       </section>
@@ -174,8 +179,8 @@ onMounted(() => {
       </section>
 
       <section
-          v-if="leafItems.length > 0"
-          class="branch-tree-other-recode-sub-title-container"
+        v-if="leafItems.length > 0"
+        class="branch-tree-other-recode-sub-title-container"
       >
         <TextMainTitle :data="{ title: `🌿 리프`, size: 24 }" />
       </section>
@@ -185,7 +190,6 @@ onMounted(() => {
         <CardAnotherRecordsList :items="leafItems" />
       </section>
     </section>
-
   </main>
 
   <Footer :noticeText="`개발 중입니다.`" />
@@ -201,7 +205,6 @@ onMounted(() => {
       <NavNavigationBar :active="'home'" />
     </section>
   </aside>
-
 </template>
 
 <style scoped>

--- a/frontend-2/pages/leaf/etc/[id]/new.vue
+++ b/frontend-2/pages/leaf/etc/[id]/new.vue
@@ -1,9 +1,8 @@
 <script setup>
-
 import Editor from "@toast-ui/editor";
 import "@toast-ui/editor/dist/toastui-editor.css";
 import { onMounted, reactive } from "vue";
-import axios, {HttpStatusCode} from "axios";
+import axios, { HttpStatusCode } from "axios";
 
 // ----------------------- Model ----------------------- //
 const config = useRuntimeConfig();
@@ -22,8 +21,7 @@ const beforeLogData = reactive({
   ],
 });
 
-const leafFormData = useState('leafFormData', () => ({
-
+const leafFormData = useState("leafFormData", () => ({
   // 태그 데이터
   tagIds: [],
   tagSelected: true,
@@ -39,21 +37,23 @@ const leafFormData = useState('leafFormData', () => ({
   visibility: true,
 }));
 
-const selectedTags = useState('selectedTags', () => ({
+const selectedTags = useState("selectedTags", () => ({
   items: [],
 }));
 
-const leafCreateUrl = useState('leafCreateUrl', () => {
+const leafCreateUrl = useState("leafCreateUrl", () => {
   return `/leaf/etc/${parentLeafId}/new`;
 });
 
-const { data: beforeLeafData, status: beforeLeafStatus } = await useFetch(`leaves/${parentLeafId}/before`, {
-  baseURL: `${config.public.apiBase}`,
-  method: "GET",
-});
+const { data: beforeLeafData, status: beforeLeafStatus } = await useAuthFetch(
+  `leaves/${parentLeafId}/before`,
+  {
+    baseURL: `${config.public.apiBase}`,
+    method: "GET",
+  }
+);
 
 watchEffect(() => {
-
   if (beforeLeafStatus.value !== HttpStatusCode.Ok) {
     // console.log("beforeLeafData : ", beforeLeafData.value);
     beforeLogData.id = beforeLeafData.value.id;
@@ -96,10 +96,13 @@ onMounted(() => {
           treeFormData.append("image", blob);
 
           // MemoirFileApiController - uploadEditorImage 메서드 호출
-          const response = await fetch(`${config.public.apiBase}/leaf/image-upload`, {
-            method: "POST",
-            body: treeFormData,
-          });
+          const response = await fetch(
+            `${config.public.apiBase}/leaf/image-upload`,
+            {
+              method: "POST",
+              body: treeFormData,
+            }
+          );
           // 컨트롤러에서 전달받은 디스크에 저장된 파일 명
           const filename = await response.text();
           // console.log("서버에 저장된 파일 명 : ", filename);
@@ -132,12 +135,13 @@ const inputTitle = (title) => {
 
 const tagDrop = (tag) => {
   // console.log("tagDrop : ", tag);
-  selectedTags.value.items = selectedTags.value.items.filter((item) => item.id !== tag.id);
+  selectedTags.value.items = selectedTags.value.items.filter(
+    (item) => item.id !== tag.id
+  );
   leafFormData.value.tagIds = selectedTags.value.items.map((tag) => tag.id);
 };
 
 const validate = () => {
-
   if (!leafFormData.value.title) {
     leafFormData.value.titleValidation = false;
     alert("리프 제목을 입력해 주세요.");
@@ -148,13 +152,15 @@ const validate = () => {
 };
 
 const submitHandler = async () => {
-
   if (!validate()) {
     return;
   }
 
   // console.log("leafFormData POST > : ", leafFormData.value);
-  const response = await axios.post(`${config.public.apiBase}/etc/leaves/${parentLeafId}`, leafFormData.value);
+  const response = await axios.post(
+    `${config.public.apiBase}/etc/leaves/${parentLeafId}`,
+    leafFormData.value
+  );
 
   if (response.status !== HttpStatusCode.Created) {
     throw new Error("Network response was not ok");
@@ -171,7 +177,6 @@ const submitHandler = async () => {
 
   router.push(`/leaf/?leafId=${leafId}`);
 };
-
 </script>
 
 <template>
@@ -179,7 +184,10 @@ const submitHandler = async () => {
     <h1 class="none">리프 생성 페이지</h1>
     <section class="tob-bar-back-container">
       <h1 class="none">리프 생성 상단 바</h1>
-      <TopBarBack title="리프 생성" :link="`/leaf?leafId=${parentLeafId}`"></TopBarBack>
+      <TopBarBack
+        title="리프 생성"
+        :link="`/leaf?leafId=${parentLeafId}`"
+      ></TopBarBack>
     </section>
   </header>
 
@@ -206,21 +214,24 @@ const submitHandler = async () => {
         <section class="etc-input-title-container">
           <h1 class="none">로그이름 입력</h1>
           <InputTextBox
-              :data="{
-                label: '*제목',
-                name: 'title',
-                placeholder: '리프 제목을 입력해 주세요.',
-                value: leafFormData.title,
-                validate: leafFormData.titleValidation,
-                validateMessage: '리프 제목을 입력해 주세요.'
-              }"
-              @inputData="inputTitle"
+            :data="{
+              label: '*제목',
+              name: 'title',
+              placeholder: '리프 제목을 입력해 주세요.',
+              value: leafFormData.title,
+              validate: leafFormData.titleValidation,
+              validateMessage: '리프 제목을 입력해 주세요.',
+            }"
+            @inputData="inputTitle"
           ></InputTextBox>
         </section>
 
         <section class="input-form__select-tag-input-container">
           <h1 class="none">리프 태그 입력</h1>
-          <InputTagSelect :selectedTag="selectedTags.items" @drop="tagDrop"></InputTagSelect>
+          <InputTagSelect
+            :selectedTag="selectedTags.items"
+            @drop="tagDrop"
+          ></InputTagSelect>
         </section>
 
         <section class="book-tree-input-form__large-input-container">
@@ -238,12 +249,17 @@ const submitHandler = async () => {
 
         <section class="input-form__input-container">
           <h1 class="none">공개성 선택</h1>
-          <InputVisibility v-model:visibility="leafFormData.visibility"></InputVisibility>
+          <InputVisibility
+            v-model:visibility="leafFormData.visibility"
+          ></InputVisibility>
         </section>
 
         <section class="book-tree-submit-container">
           <h1 class="none">리프 생성 버튼</h1>
-          <ButtonSubmitBtnFullBar text="리프 생성" @submit="submitHandler"></ButtonSubmitBtnFullBar>
+          <ButtonSubmitBtnFullBar
+            text="리프 생성"
+            @submit="submitHandler"
+          ></ButtonSubmitBtnFullBar>
         </section>
       </section>
     </form>
@@ -264,5 +280,4 @@ const submitHandler = async () => {
 .etc-input-title-container {
   margin: 40px 24px;
 }
-
 </style>

--- a/frontend-2/pages/leaf/index.vue
+++ b/frontend-2/pages/leaf/index.vue
@@ -1,7 +1,6 @@
 <script setup>
-
 import { useRoute } from "vue-router";
-import {Tree} from "~/composables/Tree.js";
+import { Tree } from "~/composables/Tree.js";
 
 // ----------------------- Model ----------------------- //
 const route = useRoute();
@@ -47,26 +46,38 @@ const focusNodeDate = reactive({
 });
 
 const btn = reactive({
-  text: "리프 생성"
+  text: "리프 생성",
 });
 
 const nodes = ref([]);
 
-const { data: seedTypeData, error: seedTypeDataError } = await useFetch(() => `leaves/${leafId}/seed`, {
-  baseURL: config.public.apiBase,
-});
+const { data: seedTypeData, error: seedTypeDataError } = await useAuthFetch(
+  () => `leaves/${leafId}/seed`,
+  {
+    baseURL: config.public.apiBase,
+  }
+);
 
-const { data: breadcrumbData, error: breadcrumbDataError } = await useFetch(() => `leaves/${leafId}/breadcrumb`, {
-  baseURL: config.public.apiBase,
-});
+const { data: breadcrumbData, error: breadcrumbDataError } = await useAuthFetch(
+  () => `leaves/${leafId}/breadcrumb`,
+  {
+    baseURL: config.public.apiBase,
+  }
+);
 
-const { data: leafAllData, error: leafAllDataError } = await useFetch(() => `leaves/${leafId}/all`, {
-  baseURL: config.public.apiBase,
-});
+const { data: leafAllData, error: leafAllDataError } = await useAuthFetch(
+  () => `leaves/${leafId}/all`,
+  {
+    baseURL: config.public.apiBase,
+  }
+);
 
-const { data: branchInfoData, error: branchInfoDataError } = await useFetch(() => `leaves/${leafId}/branch`, {
-  baseURL: config.public.apiBase,
-});
+const { data: branchInfoData, error: branchInfoDataError } = await useAuthFetch(
+  () => `leaves/${leafId}/branch`,
+  {
+    baseURL: config.public.apiBase,
+  }
+);
 
 // ----------------------- Init ----------------------- //
 if (seedTypeData.value) {
@@ -95,31 +106,30 @@ if (branchInfoData.value) {
 // ----------------------- Life Cycle ----------------------- //
 onBeforeMount(() => {
   // 화면 크기 변경 리스너 제거
-  window.removeEventListener('resize', updateWidth);
+  window.removeEventListener("resize", updateWidth);
 });
 
 onMounted(() => {
   screenWidth.value = window.innerWidth;
 
   // 화면 크기 변경에 대응하도록 리스너 추가
-  window.addEventListener('resize', updateWidth);
-  document.body.addEventListener('scroll', scrollHandler);
+  window.addEventListener("resize", updateWidth);
+  document.body.addEventListener("scroll", scrollHandler);
   scrollToElement();
 });
 
 onUnmounted(() => {
   // 화면 크기 변경 리스너 제거
-  window.removeEventListener('resize', updateWidth);
-  document.body.removeEventListener('scroll', scrollHandler);
+  window.removeEventListener("resize", updateWidth);
+  document.body.removeEventListener("scroll", scrollHandler);
 });
-
 
 // ----------------------- Function ----------------------- //
 
-const  updateWidth = () => {
+const updateWidth = () => {
   screenWidth.value = window.innerWidth;
   // console.log("화면 크기 변경", screenWidth.value);
-}
+};
 
 const scrollHandler = (event) => {
   // console.log("스크롤 이벤트 발생", event);
@@ -127,16 +137,17 @@ const scrollHandler = (event) => {
 };
 
 const findFocusNode = () => {
-  const nodes = document.querySelectorAll('.node');
-  const focusY = (window.innerHeight / 2);
+  const nodes = document.querySelectorAll(".node");
+  const focusY = window.innerHeight / 2;
   // const focusX = (window.innerWidth / 2);
 
   // console.log('start > scroll');
   // 포커스 적용 계산
   let minDistance = Number.MAX_SAFE_INTEGER;
   let minNode = null;
-  for (let node of nodes) { // 가장 가까운 노드 찾기
-    node.classList.remove('node--active');
+  for (let node of nodes) {
+    // 가장 가까운 노드 찾기
+    node.classList.remove("node--active");
     const position = node.getBoundingClientRect();
     const dist = distanceY(position.y, focusY);
 
@@ -147,43 +158,43 @@ const findFocusNode = () => {
   }
 
   // 포커스 적용
-  const focusNodeId = minNode.getAttribute('data-id');
+  const focusNodeId = minNode.getAttribute("data-id");
   for (let node of nodes) {
-    let id = node.getAttribute('data-id');
+    let id = node.getAttribute("data-id");
     if (id === focusNodeId) {
       leafCreateBtn.id = id;
       leafCreateBtn.canCreate = tree.value.isCreateBranch(id);
       // console.log('focus node', id);
-      node.classList.add('node--active');
+      node.classList.add("node--active");
     }
   }
 
   // 날짜 변경
-  const item = minNode.closest('.leaf-item');
-  const dateTag = item.querySelector('.log-item__date'); // 화면 날짜 적용
-  if (dateTag.innerText === '') {
-    focusNodeDate.title = '비공개 리프입니다.';
+  const item = minNode.closest(".leaf-item");
+  const dateTag = item.querySelector(".log-item__date"); // 화면 날짜 적용
+  if (dateTag.innerText === "") {
+    focusNodeDate.title = "비공개 리프입니다.";
   } else {
     focusNodeDate.title = formatDate(dateTag.innerText); // 화면 날짜 적용;
   }
 
   // 브래드 스크럼 변경
-  const titleTag = item.querySelector('.log-item__title');
-  if (titleTag.innerText === '') {
-    breadcrumb.leafName = '비공개 리프입니다.';
+  const titleTag = item.querySelector(".log-item__title");
+  if (titleTag.innerText === "") {
+    breadcrumb.leafName = "비공개 리프입니다.";
   } else {
     breadcrumb.leafName = titleTag.innerText;
   }
 };
 
 const formatDate = (dateString) => {
-  const [year, month, day] = dateString.split('-');
+  const [year, month, day] = dateString.split("-");
   return `${year}년 ${month}월 ${day}일`;
-}
+};
 
 const distanceY = (y1, y2) => {
   return Math.abs(y2 - y1);
-}
+};
 
 const touchStartHandler = (event) => {
   nodeSideStartEventHandler(event, targetNode.value[0]);
@@ -194,13 +205,14 @@ const touchMoveHandler = async (event, node) => {
 };
 
 const nodeSideStartEventHandler = (event, node) => {
-  if (event.type === 'touchstart') {
-    touchValue.moveStartX = event.touches[0].pageX - event.currentTarget.offsetLeft;
-  } else if (event.type === 'mousedown') {
+  if (event.type === "touchstart") {
+    touchValue.moveStartX =
+      event.touches[0].pageX - event.currentTarget.offsetLeft;
+  } else if (event.type === "mousedown") {
     isDragging.value = true;
     touchValue.moveStartX = event.pageX - event.currentTarget.offsetLeft;
   }
-}
+};
 
 const nodeSideMoveEventHandler = async (event, node) => {
   const currentTime = new Date().getTime();
@@ -210,10 +222,12 @@ const nodeSideMoveEventHandler = async (event, node) => {
   }
 
   let currentX = 0;
-  if (event.type === 'touchmove') {
+  if (event.type === "touchmove") {
     currentX = event.touches[0].pageX - event.currentTarget.offsetLeft;
-  } else if (event.type === 'mousemove') {
-    if (!isDragging.value) { return; } // 드래그 중이 아닐때
+  } else if (event.type === "mousemove") {
+    if (!isDragging.value) {
+      return;
+    } // 드래그 중이 아닐때
     currentX = event.pageX - event.currentTarget.offsetLeft;
   }
 
@@ -226,12 +240,14 @@ const nodeSideMoveEventHandler = async (event, node) => {
     return; // 스와이프 이동 중
   }
 
-    // 스와이프 인식 거리 이상 이동
-  if (0 < diffX && 0 < node.translateIndex) { // 왼쪽으로 스와이프
+  // 스와이프 인식 거리 이상 이동
+  if (0 < diffX && 0 < node.translateIndex) {
+    // 왼쪽으로 스와이프
     // console.log('인덱스 스와이프값 감소');
     node.translateIndex--;
     touchValue.moveLock = true;
-  } else if (diffX < 0 && node.translateIndex < node.childLength - 1) { // 오른쪽으로 스와이프
+  } else if (diffX < 0 && node.translateIndex < node.childLength - 1) {
+    // 오른쪽으로 스와이프
     // console.log('인덱스 스와이프값 증가');
     node.translateIndex++;
     touchValue.moveLock = true;
@@ -274,7 +290,7 @@ const nodeSideMoveEventHandler = async (event, node) => {
   touchValue.lastEventTime = new Date().getTime();
   touchValue.moveLock = false;
 
-  if (event.type === 'mousemove') {
+  if (event.type === "mousemove") {
     isDragging.value = false;
   }
 };
@@ -285,9 +301,8 @@ const mouseUpHandler = () => {
 
 const scrollToElement = () => {
   // console.log('scrollToElement', targetNode);
-  targetNode.value[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+  targetNode.value[0].scrollIntoView({ behavior: "smooth", block: "center" });
 };
-
 </script>
 
 <template @scroll="scrollHandler">
@@ -303,17 +318,20 @@ const scrollToElement = () => {
       <section class="log-path-container">
         <h1 class="none">리프 경로</h1>
         <BarLogPath
-            :data="{
-                tree: breadcrumb.treeName,
-                branch: breadcrumb.branchName,
-                leaf: breadcrumb.leafName
-            }"
+          :data="{
+            tree: breadcrumb.treeName,
+            branch: breadcrumb.branchName,
+            leaf: breadcrumb.leafName,
+          }"
         ></BarLogPath>
       </section>
 
       <section class="log-list-date-title-container">
         <h1 class="none">리프 날짜</h1>
-        <TextMainTitleRight :title="focusNodeDate.title" :size="focusNodeDate.size"></TextMainTitleRight>
+        <TextMainTitleRight
+          :title="focusNodeDate.title"
+          :size="focusNodeDate.size"
+        ></TextMainTitleRight>
       </section>
     </section>
   </header>
@@ -322,15 +340,19 @@ const scrollToElement = () => {
     <section class="log-list-container">
       <h1 class="none">리프 리스트</h1>
       <section
-               v-for="node in nodes"
-               :ref="node.id === leafId ? 'targetNode' : ''"
+        v-for="node in nodes"
+        :ref="node.id === leafId ? 'targetNode' : ''"
       >
-        <div class="log-item-container"
-             @touchstart="touchStartHandler"
-             @touchmove="(event) => touchMoveHandler(event, node)"
-             @mousedown="touchStartHandler"
-             @mousemove="(event) => touchMoveHandler(event, node)"
-             :style="{ transform: `translateX(-${node.translateSize(screenWidth)}px)` }">
+        <div
+          class="log-item-container"
+          @touchstart="touchStartHandler"
+          @touchmove="(event) => touchMoveHandler(event, node)"
+          @mousedown="touchStartHandler"
+          @mousemove="(event) => touchMoveHandler(event, node)"
+          :style="{
+            transform: `translateX(-${node.translateSize(screenWidth)}px)`,
+          }"
+        >
           <div v-if="node.isLeft" class="log-item__left-box">
             <LogItem :data="node.leftData"></LogItem>
           </div>
@@ -349,7 +371,11 @@ const scrollToElement = () => {
     <h1 class="none">브랜치 정보 알림 하단 바</h1>
     <section class="log-list-bot-btn-container">
       <h1 class="none">리프 생성 버튼</h1>
-      <ButtonBtnShortAGreen :visibility="leafCreateBtn.canCreate" :link="`/leaf/${seedType}/${leafCreateBtn.id}/new`" :text="`리프 생성`"/>
+      <ButtonBtnShortAGreen
+        :visibility="leafCreateBtn.canCreate"
+        :link="`/leaf/${seedType}/${leafCreateBtn.id}/new`"
+        :text="`리프 생성`"
+      />
     </section>
 
     <section class="log-list-bot-bar-info-container">
@@ -360,7 +386,6 @@ const scrollToElement = () => {
 </template>
 
 <style scoped>
-
 main {
   width: 100%;
   height: 100%;

--- a/frontend-2/pages/member/find/email.vue
+++ b/frontend-2/pages/member/find/email.vue
@@ -1,19 +1,17 @@
 <script setup>
-
 const config = useRuntimeConfig();
 
 // ----------------------- Model ----------------------- //
 const findUserInfo = ref({
-
-  username: '',
+  username: "",
   isUsernameValid: true,
-  usernameValidateMessage: '이름을 입력해주세요.',
+  usernameValidateMessage: "이름을 입력해주세요.",
 
-  email: '',
+  email: "",
   isEmailValid: true,
-  emailValidateMessage: '이메일을 입력해주세요.',
+  emailValidateMessage: "이메일을 입력해주세요.",
 
-  disabled: false
+  disabled: false,
 });
 
 // ----------------------- API ----------------------- //
@@ -21,19 +19,22 @@ const sendEmailApi = async () => {
   findUserInfo.value.disabled = true;
   // API
   try {
-    const response = await $fetch(`${config.public.apiBase}/members/find/send-email`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        username: findUserInfo.value.username,
-        email: findUserInfo.value.email
-      })
-    });
+    const response = await useAuthDataFetch(
+      `${config.public.apiBase}/members/find/send-email`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          username: findUserInfo.value.username,
+          email: findUserInfo.value.email,
+        }),
+      }
+    );
 
     if (!response.success) {
-      console.error('이메일 전송 실패');
+      console.error("이메일 전송 실패");
       findUserInfo.value.disabled = false;
       return;
     }
@@ -53,11 +54,10 @@ const inputUsername = (username) => {
 };
 
 const sendEmailHandler = () => {
-
   // 이름 확인
-  if (findUserInfo.value.username === '') {
+  if (findUserInfo.value.username === "") {
     findUserInfo.value.isUsernameValid = false;
-    findUserInfo.value.usernameValidateMessage = '이름을 입력해주세요.';
+    findUserInfo.value.usernameValidateMessage = "이름을 입력해주세요.";
     return;
   } else {
     findUserInfo.value.isUsernameValid = true;
@@ -67,60 +67,66 @@ const sendEmailHandler = () => {
   const emailRegExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   if (!emailRegExp.test(findUserInfo.value.email)) {
     findUserInfo.value.isEmailValid = false;
-    findUserInfo.value.emailValidateMessage = '이메일 형식이 올바르지 않습니다.';
+    findUserInfo.value.emailValidateMessage =
+      "이메일 형식이 올바르지 않습니다.";
     return;
   } else {
     findUserInfo.value.isEmailValid = true;
   }
 
-  console.log('이메일 전송');
+  console.log("이메일 전송");
   sendEmailApi();
 };
-
 </script>
 
 <template>
   <div class="login-member__join-page-container">
     <ButtonLoginJoinPageBackBtn :data="{ link: '/member/login' }" />
     <TextLoginPageInfo
-        :data="{
-          label: '계정 찾기',
-          infoText: '비밀번호 재설정 링크를 보내드립니다.'
-        }"
+      :data="{
+        label: '계정 찾기',
+        infoText: '비밀번호 재설정 링크를 보내드립니다.',
+      }"
     />
     <form @submit.prevent="sendEmailHandler">
       <InputTextBar
-          :data="{
+        :data="{
           label: '이름',
           name: 'username',
           placeholder: '이름을 입력해주세요.',
           inputType: 'email',
           disabled: findUserInfo.disabled,
           isValid: findUserInfo.isUsernameValid,
-          validateMessage: findUserInfo.usernameValidateMessage
+          validateMessage: findUserInfo.usernameValidateMessage,
         }"
-          @inputData="inputUsername"
+        @inputData="inputUsername"
       />
       <InputTextBar
-          :data="{
+        :data="{
           label: '이메일',
           name: 'email',
           placeholder: '이메일을 입력해주세요.',
           inputType: 'email',
           disabled: findUserInfo.disabled,
           isValid: findUserInfo.isEmailValid,
-          validateMessage: findUserInfo.emailValidateMessage
+          validateMessage: findUserInfo.emailValidateMessage,
         }"
         @inputData="inputEmail"
       />
-      <ButtonSubmitBtnFullBar text="이메일 전송" :is-submit="findUserInfo.disabled" @submit="sendEmailHandler"/>
+      <ButtonSubmitBtnFullBar
+        text="이메일 전송"
+        :is-submit="findUserInfo.disabled"
+        @submit="sendEmailHandler"
+      />
     </form>
-    <TextJoinGuide :data="{
-      infoText: '이미 계정이 있으신가요?',
-      label: '로그인',
-      href: '/member/login',
-      isFind: false
-    }" />
+    <TextJoinGuide
+      :data="{
+        infoText: '이미 계정이 있으신가요?',
+        label: '로그인',
+        href: '/member/login',
+        isFind: false,
+      }"
+    />
   </div>
 </template>
 

--- a/frontend-2/pages/member/join/email.vue
+++ b/frontend-2/pages/member/join/email.vue
@@ -1,38 +1,40 @@
 <script setup>
-import {HttpStatusCode} from "axios";
+import { HttpStatusCode } from "axios";
 
 const config = useRuntimeConfig();
 
 // ----------------------- Model ----------------------- //
 const joinEmail = ref({
-  email: '',
+  email: "",
   isEmailValid: true,
-  emailValidateMessage: '이메일을 입력해주세요.',
-  disabled: false
+  emailValidateMessage: "이메일을 입력해주세요.",
+  disabled: false,
 });
 
 // ----------------------- API ----------------------- //
 const sendEmailApi = async () => {
-  alert('이메일 전송 성공');
+  alert("이메일 전송 성공");
   joinEmail.value.disabled = true;
 
   // API
   try {
-    const response = await $fetch(`${config.public.apiBase}/members/join/send-email`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({
-        email: joinEmail.value.email
-      })
-    });
+    const response = await useAuthDataFetch(
+      `${config.public.apiBase}/members/join/send-email`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email: joinEmail.value.email,
+        }),
+      }
+    );
 
     if (!response.success) {
-      console.error('이메일 전송 실패');
+      console.error("이메일 전송 실패");
       return;
     }
-
   } catch (error) {
     console.log(error);
   }
@@ -44,58 +46,61 @@ const inputEmail = (email) => {
 };
 
 const sendEmailHandler = () => {
-
   // 이메일 형식 확인
   const emailRegExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   if (!emailRegExp.test(joinEmail.value.email)) {
     joinEmail.value.isEmailValid = false;
-    joinEmail.value.emailValidateMessage = '이메일 형식이 올바르지 않습니다.';
+    joinEmail.value.emailValidateMessage = "이메일 형식이 올바르지 않습니다.";
     return;
   } else {
     joinEmail.value.isEmailValid = true;
   }
 
-  console.log('이메일 전송');
+  console.log("이메일 전송");
   sendEmailApi();
 };
-
 </script>
 
 <template>
   <div class="login-member__join-page-container">
     <ButtonLoginJoinPageBackBtn :data="{ link: '/member/login' }" />
     <TextLoginPageInfo
-        :data="{
-          label: '회원가입',
-          infoText: '이메일로 회원가입을 진행합니다'
-        }"
+      :data="{
+        label: '회원가입',
+        infoText: '이메일로 회원가입을 진행합니다',
+      }"
     />
     <form @submit.prevent="sendEmailHandler">
       <InputTextBar
-          :data="{
+        :data="{
           label: '이메일',
           name: 'email',
           placeholder: '이메일을 입력해주세요.',
           inputType: 'email',
           disabled: joinEmail.disabled,
           isValid: joinEmail.isEmailValid,
-          validateMessage: joinEmail.emailValidateMessage
+          validateMessage: joinEmail.emailValidateMessage,
         }"
         @inputData="inputEmail"
       />
-      <ButtonSubmitBtnFullBar text="회원가입" :is-submit="joinEmail.disabled" @submit="sendEmailHandler"/>
+      <ButtonSubmitBtnFullBar
+        text="회원가입"
+        :is-submit="joinEmail.disabled"
+        @submit="sendEmailHandler"
+      />
     </form>
     <LinkSocialLogin />
-    <TextJoinGuide :data="{
-      infoText: '이미 계정이 있으신가요?',
-      label: '로그인',
-      href: '/member/login'
-    }" />
+    <TextJoinGuide
+      :data="{
+        infoText: '이미 계정이 있으신가요?',
+        label: '로그인',
+        href: '/member/login',
+      }"
+    />
   </div>
 </template>
 
 <style scoped>
-
 .login-member__join-page-container {
   width: auto;
   padding: 50px 24px 0 24px;

--- a/frontend-2/pages/member/login.vue
+++ b/frontend-2/pages/member/login.vue
@@ -1,9 +1,7 @@
 <script setup>
-import { useMemberDetail } from "~/composables/useMemberDetail.js";
-
 const config = useRuntimeConfig();
 const router = useRouter();
-const memberDetail = useMemberDetail();
+const memberDetail = useMemberStore();
 
 // ----------------------- Model ----------------------- //
 const loginInfo = ref({
@@ -32,6 +30,7 @@ const loginApi = async () => {
       }),
     });
 
+    console.log(response);
     memberDetail.setAuthWithToken(response.accessToken);
     //현재 URL에서 returnUrl 값을 가져오기
     const returnUrl = router.currentRoute.value.query.retrunUrl || "/home";

--- a/frontend-2/pages/member/new.vue
+++ b/frontend-2/pages/member/new.vue
@@ -1,77 +1,74 @@
 <script setup>
-
 const config = useRuntimeConfig();
 const route = useRoute();
 const key = ref(route.query.key);
 
 // ----------------------- Method ----------------------- //
 const joinInfo = ref({
-
-  name: '',
+  name: "",
   isNameValid: true,
-  nameValidateMessage: '이름을 입력해주세요.',
+  nameValidateMessage: "이름을 입력해주세요.",
 
-  email: '',
+  email: "",
   isEmailValid: true,
-  emailValidateMessage: '이메일을 입력해주세요.',
+  emailValidateMessage: "이메일을 입력해주세요.",
 
-  password: '',
+  password: "",
   isPasswordValid: true,
-  passwordValidateMessage: '비밀번호를 입력해주세요 (8~32자, 대소문자 포함, 숫자, 특스문자 1개이상 포함)',
+  passwordValidateMessage:
+    "비밀번호를 입력해주세요 (8~32자, 대소문자 포함, 숫자, 특스문자 1개이상 포함)",
 
-  passwordCheck: '',
+  passwordCheck: "",
   isPasswordCheckValid: true,
-  passwordCheckValidateMessage: '동일한 비밀번호를 입력해주세요.',
+  passwordCheckValidateMessage: "동일한 비밀번호를 입력해주세요.",
 
-  nickname: '',
+  nickname: "",
   isNicknameValid: true,
-  nicknameValidateMessage: '닉네임을 입력해주세요.',
+  nicknameValidateMessage: "닉네임을 입력해주세요.",
 
-  introduction: '',
+  introduction: "",
   isIntroductionValid: true,
-  introductionValidateMessage: '한 줄 소개를 입력해주세요.',
+  introductionValidateMessage: "한 줄 소개를 입력해주세요.",
 
-  isPolicyAgreement: false
+  isPolicyAgreement: false,
 });
 // ----------------------- API ----------------------- //
-const { data: emailInfo, error: emailInfoError } = await useFetch(
-    `members/join/check-email`,
-    {
-      method: "POST",
-      baseURL: `${config.public.apiBase}`,
-      headers: { "Content-Type": "application/json" },
-      body: { key: key.value }
-    },
+const { data: emailInfo, error: emailInfoError } = await useAuthFetch(
+  `members/join/check-email`,
+  {
+    method: "POST",
+    baseURL: `${config.public.apiBase}`,
+    headers: { "Content-Type": "application/json" },
+    body: { key: key.value },
+  }
 );
 
 const joinPostApi = async () => {
   try {
-    const response = await $fetch(`members/join`,
-        {
-          method: "POST",
-          baseURL: `${config.public.apiBase}`,
-          headers: { "Content-Type": "application/json" },
-          body: {
-            username: joinInfo.value.name,
-            joinToken: key.value,
-            email: joinInfo.value.email,
-            password: joinInfo.value.password,
-            nickname: joinInfo.value.nickname,
-            introduction: joinInfo.value.introduction
-          }
-        },
-    );
+    const response = await useAuthDataFetch(`members/join`, {
+      method: "POST",
+      baseURL: `${config.public.apiBase}`,
+      headers: { "Content-Type": "application/json" },
+      body: {
+        username: joinInfo.value.name,
+        joinToken: key.value,
+        email: joinInfo.value.email,
+        password: joinInfo.value.password,
+        nickname: joinInfo.value.nickname,
+        introduction: joinInfo.value.introduction,
+      },
+    });
 
     if (response.status !== 201) {
-      alert('회원가입이 완료되었습니다.');
+      alert("회원가입이 완료되었습니다.");
       return;
     }
 
-    alert('회원가입이 완료되었습니다.');
+    alert("회원가입이 완료되었습니다.");
   } catch (error) {
     alert(error.data.message);
   }
-}
+};
 
 watchEffect(() => {
   if (emailInfo.value) {
@@ -79,71 +76,77 @@ watchEffect(() => {
   }
 });
 
-
 // ----------------------- Method ----------------------- //
 
 const inputName = (name) => {
   joinInfo.value.name = name;
-}
+};
 
 const inputEmail = (email) => {
   joinInfo.value.email = email;
-}
+};
 
 const inputPassword = (password) => {
   joinInfo.value.password = password;
 
   // 8~32자
-  if (!(8 <= joinInfo.value.password.length && joinInfo.value.password.length <= 32)) {
+  if (
+    !(
+      8 <= joinInfo.value.password.length &&
+      joinInfo.value.password.length <= 32
+    )
+  ) {
     joinInfo.value.isPasswordValid = false;
-    joinInfo.value.passwordValidateMessage = '비밀번호는 8~32자로 입력해주세요.';
+    joinInfo.value.passwordValidateMessage =
+      "비밀번호는 8~32자로 입력해주세요.";
     return;
   }
-  joinInfo.value.passwordValidateMessage = '';
+  joinInfo.value.passwordValidateMessage = "";
 
   // 대소문자 포함, 숫자
   if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(joinInfo.value.password)) {
     joinInfo.value.isPasswordValid = false;
-    joinInfo.value.passwordValidateMessage = '비밀번호는 대소문자, 숫자를 포함해주세요.';
+    joinInfo.value.passwordValidateMessage =
+      "비밀번호는 대소문자, 숫자를 포함해주세요.";
     return;
   }
-  joinInfo.value.passwordValidateMessage = '';
+  joinInfo.value.passwordValidateMessage = "";
 
   // 특스문자 1개이상 포함
   if (!/^(?=.*[!@#$%^&*])/.test(joinInfo.value.password)) {
     joinInfo.value.isPasswordValid = false;
-    joinInfo.value.passwordValidateMessage = '비밀번호는 특수문자를 포함해주세요.';
+    joinInfo.value.passwordValidateMessage =
+      "비밀번호는 특수문자를 포함해주세요.";
     return;
   }
-  joinInfo.value.passwordValidateMessage = '';
-}
+  joinInfo.value.passwordValidateMessage = "";
+};
 
 const inputPasswordCheck = (passwordCheck) => {
   joinInfo.value.passwordCheck = passwordCheck;
   if (joinInfo.value.password !== joinInfo.value.passwordCheck) {
     joinInfo.value.isPasswordCheckValid = false;
-    joinInfo.value.passwordCheckValidateMessage = '비밀번호가 일치하지 않습니다.';
-  } else
-    joinInfo.value.isPasswordCheckValid = true;
-}
+    joinInfo.value.passwordCheckValidateMessage =
+      "비밀번호가 일치하지 않습니다.";
+  } else joinInfo.value.isPasswordCheckValid = true;
+};
 
 const inputNickname = (nickname) => {
   joinInfo.value.nickname = nickname;
-}
+};
 
 const inputIntroduction = (introduction) => {
   joinInfo.value.introduction = introduction;
-}
+};
 
 const inputPolicyAgreement = (isPolicyAgreement) => {
   joinInfo.value.isPolicyAgreement = isPolicyAgreement;
-}
+};
 
 const submitJoin = () => {
-
-  if (joinInfo.value.name === '') {
+  if (joinInfo.value.name === "") {
     joinInfo.value.isNameValid = false;
-    joinInfo.value.nameValidateMessage = '이름을 입력해주세요.';
+    joinInfo.value.nameValidateMessage = "이름을 입력해주세요.";
   } else {
     joinInfo.value.isNameValid = true;
   }
@@ -151,81 +154,90 @@ const submitJoin = () => {
   const emailRegExp = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
   if (!emailRegExp.test(joinInfo.value.email)) {
     joinInfo.value.isEmailValid = false;
-    joinInfo.value.emailValidateMessage = '이메일 형식이 올바르지 않습니다.';
+    joinInfo.value.emailValidateMessage = "이메일 형식이 올바르지 않습니다.";
   } else {
     joinInfo.value.isEmailValid = true;
   }
 
-  if (joinInfo.value.password === '') {
+  if (joinInfo.value.password === "") {
     joinInfo.value.isPasswordValid = false;
-    joinInfo.value.passwordValidateMessage = '비밀번호를 입력해주세요.';
+    joinInfo.value.passwordValidateMessage = "비밀번호를 입력해주세요.";
   } else {
-
     // 8~32자
-    if (!(8 <= joinInfo.value.password.length && joinInfo.value.password.length <= 32)) {
+    if (
+      !(
+        8 <= joinInfo.value.password.length &&
+        joinInfo.value.password.length <= 32
+      )
+    ) {
       joinInfo.value.isPasswordValid = false;
-      joinInfo.value.passwordValidateMessage = '비밀번호는 8~32자로 입력해주세요.';
+      joinInfo.value.passwordValidateMessage =
+        "비밀번호는 8~32자로 입력해주세요.";
     }
 
     // 대소문자 포함, 숫자
     if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(joinInfo.value.password)) {
       joinInfo.value.isPasswordValid = false;
-      joinInfo.value.passwordValidateMessage = '비밀번호는 대소문자, 숫자를 포함해주세요.';
+      joinInfo.value.passwordValidateMessage =
+        "비밀번호는 대소문자, 숫자를 포함해주세요.";
     }
 
     // 특스문자 1개이상 포함
     if (!/^(?=.*[!@#$%^&*])/.test(joinInfo.value.password)) {
       joinInfo.value.isPasswordValid = false;
-      joinInfo.value.passwordValidateMessage = '비밀번호는 특수문자를 포함해주세요.';
+      joinInfo.value.passwordValidateMessage =
+        "비밀번호는 특수문자를 포함해주세요.";
     }
 
     joinInfo.value.isPasswordValid = true;
   }
 
-  if (joinInfo.value.passwordCheck === '') {
+  if (joinInfo.value.passwordCheck === "") {
     joinInfo.value.isPasswordCheckValid = false;
-    joinInfo.value.passwordCheckValidateMessage = '비밀번호 확인을 입력해주세요.';
+    joinInfo.value.passwordCheckValidateMessage =
+      "비밀번호 확인을 입력해주세요.";
   } else {
     if (joinInfo.value.password !== joinInfo.value.passwordCheck) {
       joinInfo.value.isPasswordCheckValid = false;
-      joinInfo.value.passwordCheckValidateMessage = '비밀번호가 일치하지 않습니다.';
-    } else
-    joinInfo.value.isPasswordCheckValid = true;
+      joinInfo.value.passwordCheckValidateMessage =
+        "비밀번호가 일치하지 않습니다.";
+    } else joinInfo.value.isPasswordCheckValid = true;
   }
 
-  if (joinInfo.value.nickname === '') {
+  if (joinInfo.value.nickname === "") {
     joinInfo.value.isNicknameValid = false;
-    joinInfo.value.nicknameValidateMessage = '닉네임을 입력해주세요.';
+    joinInfo.value.nicknameValidateMessage = "닉네임을 입력해주세요.";
   } else {
     joinInfo.value.isNicknameValid = true;
   }
 
-  if (joinInfo.value.introduction === '') {
+  if (joinInfo.value.introduction === "") {
     joinInfo.value.isIntroductionValid = false;
-    joinInfo.value.introductionValidateMessage = '한 줄 소개를 입력해주세요.';
+    joinInfo.value.introductionValidateMessage = "한 줄 소개를 입력해주세요.";
   } else {
     joinInfo.value.isIntroductionValid = true;
   }
 
   if (!joinInfo.value.isPolicyAgreement) {
-    alert('이용약관에 동의해주세요.');
+    alert("이용약관에 동의해주세요.");
   }
 
-  if (!joinInfo.value.isNameValid ||
-      !joinInfo.value.isEmailValid ||
-      !joinInfo.value.isPasswordValid ||
-      !joinInfo.value.isPasswordCheckValid ||
-      !joinInfo.value.isNicknameValid ||
-      !joinInfo.value.isIntroductionValid) {
-    alert('입력 정보를 확인해주세요.');
+  if (
+    !joinInfo.value.isNameValid ||
+    !joinInfo.value.isEmailValid ||
+    !joinInfo.value.isPasswordValid ||
+    !joinInfo.value.isPasswordCheckValid ||
+    !joinInfo.value.isNicknameValid ||
+    !joinInfo.value.isIntroductionValid
+  ) {
+    alert("입력 정보를 확인해주세요.");
     return;
   }
 
   // 회원가입 API 호출
   joinPostApi();
-  router.push('/member/login');
-}
-
+  route.push("/member/login");
+};
 </script>
 
 <template>
@@ -233,70 +245,76 @@ const submitJoin = () => {
     <TextJoinPageInfo label="회원가입" info-text="기본 정보를 작성해주세요" />
     <form @submit="submitJoin">
       <InputTextBar
-          :data="{
+        :data="{
           label: '*이름',
           name: 'name',
           placeholder: '이름을 입력해주세요',
           inputType: 'text',
           isValid: joinInfo.isNameValid,
-          validateMessage: joinInfo.nameValidateMessage
+          validateMessage: joinInfo.nameValidateMessage,
         }"
-          @inputData="inputName"
+        @inputData="inputName"
       />
       <div class="input-text__bar">
         <label class="input-text__label">
           <span class="input-text__label-text">* 이메일</span>
-          <input class="input-text__input" name="email" disabled :value="joinInfo.email" />
+          <input
+            class="input-text__input"
+            name="email"
+            disabled
+            :value="joinInfo.email"
+          />
         </label>
         <div class="wrong-text-box"></div>
       </div>
       <InputTextBar
-          :data="{
+        :data="{
           label: '*비밀번호',
           name: 'password',
           placeholder: '비밀번호 입력',
           inputType: 'password',
           isValid: joinInfo.isPasswordValid,
-          validateMessage: joinInfo.passwordValidateMessage
+          validateMessage: joinInfo.passwordValidateMessage,
         }"
-          @inputData="inputPassword"
+        @inputData="inputPassword"
       />
       <InputTextBar
-          :data="{
+        :data="{
           label: '*비밀번호 확인',
           name: 'passwordCheck',
           placeholder: '동일한 비밀번호를 입력해주세요',
           inputType: 'password',
           isValid: joinInfo.isPasswordCheckValid,
-          validateMessage: joinInfo.passwordCheckValidateMessage
+          validateMessage: joinInfo.passwordCheckValidateMessage,
         }"
-          @inputData="inputPasswordCheck"
+        @inputData="inputPasswordCheck"
       />
       <InputTextBar
-          :data="{
+        :data="{
           label: '*닉네임',
           name: 'nickname',
           placeholder: '닉네임을 입력해주세요',
           inputType: 'text',
           isValid: joinInfo.isNicknameValid,
-          validateMessage: joinInfo.nicknameValidateMessage
+          validateMessage: joinInfo.nicknameValidateMessage,
         }"
-          @inputData="inputNickname"
+        @inputData="inputNickname"
       />
       <InputTextBar
-          :data="{
+        :data="{
           label: '*한 줄 소개',
           name: 'introduction',
           placeholder: '한 줄 소개를 입력해주세요',
           inputType: 'text',
           isValid: joinInfo.isIntroductionValid,
-          validateMessage: joinInfo.introductionValidateMessage
+          validateMessage: joinInfo.introductionValidateMessage,
         }"
-          @inputData="inputIntroduction"
+        @inputData="inputIntroduction"
       />
       <InputCheckboxJoinPolicyAgreement
-          @checkEvent="inputPolicyAgreement"
-          text="이용약관 동의"/>
+        @checkEvent="inputPolicyAgreement"
+        text="이용약관 동의"
+      />
       <ButtonSubmitBtnFullBar text="회원가입" @submit="submitJoin" />
     </form>
   </div>
@@ -308,4 +326,3 @@ const submitJoin = () => {
   padding: 50px 24px 0 24px;
 }
 </style>
-

--- a/frontend-2/pages/member/oauth/new.vue
+++ b/frontend-2/pages/member/oauth/new.vue
@@ -1,6 +1,5 @@
 <script setup>
-
-import {useMemberJoinTmp} from "~/composables/useMemberJoinTmp.js";
+import { useMemberJoinTmp } from "~/composables/useMemberJoinTmp.js";
 
 const config = useRuntimeConfig();
 const route = useRoute();
@@ -9,78 +8,74 @@ const key = ref(route.query.key);
 
 // ----------------------- Method ----------------------- //
 const oauthInfo = ref({
-  name: '',
-  email: '',
-  picture: ''
+  name: "",
+  email: "",
+  picture: "",
 });
 
 oauthInfo.value = useMemberJoinTmp().getJoinInfo();
 
 const joinInfo = ref({
-
   name: oauthInfo.value.name,
   isNameValid: true,
-  nameValidateMessage: '이름을 입력해주세요.',
+  nameValidateMessage: "이름을 입력해주세요.",
 
   email: oauthInfo.value.email,
   isEmailValid: true,
-  emailValidateMessage: '이메일을 입력해주세요.',
+  emailValidateMessage: "이메일을 입력해주세요.",
 
-  nickname: '',
+  nickname: "",
   isNicknameValid: true,
-  nicknameValidateMessage: '닉네임을 입력해주세요.',
+  nicknameValidateMessage: "닉네임을 입력해주세요.",
 
-  introduction: '',
+  introduction: "",
   isIntroductionValid: true,
-  introductionValidateMessage: '한 줄 소개를 입력해주세요.',
+  introductionValidateMessage: "한 줄 소개를 입력해주세요.",
 
-  isPolicyAgreement: false
+  isPolicyAgreement: false,
 });
 
-
 // ----------------------- API ----------------------- //
-const { data: emailInfo, error: emailInfoError } = await useFetch(
-    `members/join/check-email`,
-    {
-      method: "POST",
-      baseURL: `${config.public.apiBase}`,
-      headers: { "Content-Type": "application/json" },
-      body: { key: key.value }
-    },
+const { data: emailInfo, error: emailInfoError } = await useAuthFetch(
+  `members/join/check-email`,
+  {
+    method: "POST",
+    baseURL: `${config.public.apiBase}`,
+    headers: { "Content-Type": "application/json" },
+    body: { key: key.value },
+  }
 );
 
 const joinPostApi = async () => {
   try {
-    const response = await $fetch(`members/oauth/join`,
-        {
-          method: "POST",
-          baseURL: `${config.public.apiBase}`,
-          headers: { "Content-Type": "application/json" },
-          body: {
-            name: joinInfo.value.name,
-            email: joinInfo.value.email,
-            password: joinInfo.value.password,
-            nickname: joinInfo.value.nickname,
-            introduction: joinInfo.value.introduction,
-            picture: oauthInfo.value.picture
-          }
-        },
-    );
+    const response = await useAuthDataFetch(`members/oauth/join`, {
+      method: "POST",
+      baseURL: `${config.public.apiBase}`,
+      headers: { "Content-Type": "application/json" },
+      body: {
+        name: joinInfo.value.name,
+        email: joinInfo.value.email,
+        password: joinInfo.value.password,
+        nickname: joinInfo.value.nickname,
+        introduction: joinInfo.value.introduction,
+        picture: oauthInfo.value.picture,
+      },
+    });
 
-    if (response.message !== '로그인 성공') {
-      alert('회원가입에 실패했습니다.');
+    if (response.message !== "로그인 성공") {
+      alert("회원가입에 실패했습니다.");
       return;
     }
 
     console.log(response.accessToken);
-    useMemberDetail().setAuthWithToken(response.accessToken);
+    useMemberStore().setAuthWithToken(response.accessToken);
 
-    alert('회원가입이 완료되었습니다.');
-    router.push('/home');
+    alert("회원가입이 완료되었습니다.");
+    router.push("/home");
   } catch (error) {
     alert(error.data.message);
   }
-}
+};
 
 watchEffect(() => {
   if (emailInfo.value) {
@@ -88,93 +83,102 @@ watchEffect(() => {
   }
 });
 
-
 // ----------------------- Method ----------------------- //
 
 const inputNickname = (nickname) => {
   joinInfo.value.nickname = nickname;
-}
+};
 
 const inputIntroduction = (introduction) => {
   joinInfo.value.introduction = introduction;
-}
+};
 
 const inputPolicyAgreement = (isPolicyAgreement) => {
   joinInfo.value.isPolicyAgreement = isPolicyAgreement;
-}
+};
 
 const submitJoin = () => {
-
-  if (joinInfo.value.nickname === '') {
+  if (joinInfo.value.nickname === "") {
     joinInfo.value.isNicknameValid = false;
-    joinInfo.value.nicknameValidateMessage = '닉네임을 입력해주세요.';
+    joinInfo.value.nicknameValidateMessage = "닉네임을 입력해주세요.";
   } else {
     joinInfo.value.isNicknameValid = true;
   }
 
-  if (joinInfo.value.introduction === '') {
+  if (joinInfo.value.introduction === "") {
     joinInfo.value.isIntroductionValid = false;
-    joinInfo.value.introductionValidateMessage = '한 줄 소개를 입력해주세요.';
+    joinInfo.value.introductionValidateMessage = "한 줄 소개를 입력해주세요.";
   } else {
     joinInfo.value.isIntroductionValid = true;
   }
 
   if (!joinInfo.value.isPolicyAgreement) {
-    alert('이용약관에 동의해주세요.');
+    alert("이용약관에 동의해주세요.");
   }
 
-  if (!joinInfo.value.isNicknameValid ||
-      !joinInfo.value.isIntroductionValid) {
-    alert('입력 정보를 확인해주세요.');
+  if (!joinInfo.value.isNicknameValid || !joinInfo.value.isIntroductionValid) {
+    alert("입력 정보를 확인해주세요.");
     return;
   }
 
   // 회원가입 API 호출
   joinPostApi();
-  router.push('/member/home');
-}
-
+  router.push("/member/home");
+};
 </script>
 
 <template>
   <div class="login-member__join-page-container">
-    <TextJoinPageInfo label="회원가입" info-text="GGoggit 기본 정보를 작성해주세요." />
+    <TextJoinPageInfo
+      label="회원가입"
+      info-text="GGoggit 기본 정보를 작성해주세요."
+    />
     <form @submit="submitJoin">
       <div class="input-text__bar">
         <label class="input-text__label">
           <span class="input-text__label-text">* 이름</span>
-          <input class="input-text__input" name="name" disabled :value="joinInfo.name" />
+          <input
+            class="input-text__input"
+            name="name"
+            disabled
+            :value="joinInfo.name"
+          />
         </label>
         <div class="wrong-text-box"></div>
       </div>
       <div class="input-text__bar">
         <label class="input-text__label">
           <span class="input-text__label-text">* 이메일</span>
-          <input class="input-text__input" name="email" disabled :value="joinInfo.email" />
+          <input
+            class="input-text__input"
+            name="email"
+            disabled
+            :value="joinInfo.email"
+          />
         </label>
         <div class="wrong-text-box"></div>
       </div>
       <InputTextBar
-          :data="{
+        :data="{
           label: '*닉네임',
           name: 'nickname',
           placeholder: '닉네임을 입력해주세요',
           inputType: 'text',
           isValid: joinInfo.isNicknameValid,
-          validateMessage: joinInfo.nicknameValidateMessage
+          validateMessage: joinInfo.nicknameValidateMessage,
         }"
-          @inputData="inputNickname"
+        @inputData="inputNickname"
       />
       <InputTextBar
-          :data="{
+        :data="{
           label: '*한 줄 소개',
           name: 'introduction',
           placeholder: '한 줄 소개를 입력해주세요',
           inputType: 'text',
           isValid: joinInfo.isIntroductionValid,
-          validateMessage: joinInfo.introductionValidateMessage
+          validateMessage: joinInfo.introductionValidateMessage,
         }"
-          @inputData="inputIntroduction"
+        @inputData="inputIntroduction"
       />
       <div class="none">
         <label>
@@ -182,8 +186,9 @@ const submitJoin = () => {
         </label>
       </div>
       <InputCheckboxJoinPolicyAgreement
-          @checkEvent="inputPolicyAgreement"
-          text="이용약관 동의"/>
+        @checkEvent="inputPolicyAgreement"
+        text="이용약관 동의"
+      />
       <ButtonSubmitBtnFullBar text="회원가입" @submit="submitJoin" />
     </form>
   </div>
@@ -195,4 +200,3 @@ const submitJoin = () => {
   padding: 50px 24px 0 24px;
 }
 </style>
-

--- a/frontend-2/pages/member/password-reset.vue
+++ b/frontend-2/pages/member/password-reset.vue
@@ -1,5 +1,4 @@
 <script setup>
-
 const config = useRuntimeConfig();
 const router = useRouter();
 const route = useRoute();
@@ -10,42 +9,41 @@ console.log(key.value);
 // ----------------------- Model ----------------------- //
 
 const resetInfo = ref({
+  email: "",
 
-  email: '',
-
-  password: '',
+  password: "",
   isPasswordValid: true,
-  passwordValidateMessage: '비밀번호를 입력해주세요.',
+  passwordValidateMessage: "비밀번호를 입력해주세요.",
 
-  passwordCheck: '',
+  passwordCheck: "",
   isPasswordCheckValid: true,
-  passwordCheckValidateMessage: '비밀번호를 다시 입력해주세요.'
+  passwordCheckValidateMessage: "비밀번호를 다시 입력해주세요.",
 });
 
 // ----------------------- Method ----------------------- //
-const { data: emailInfo, error: emailInfoError } = await useFetch(`members/password/check-email`,
-    {
-      method: "POST",
-      baseURL: `${config.public.apiBase}`,
-      headers: { "Content-Type": "application/json" },
-      body: { key: key.value }
-    },
+const { data: emailInfo, error: emailInfoError } = await useAuthFetch(
+  `members/password/check-email`,
+  {
+    method: "POST",
+    baseURL: `${config.public.apiBase}`,
+    headers: { "Content-Type": "application/json" },
+    body: { key: key.value },
+  }
 );
 
 const passwordResetApi = async () => {
-
   try {
-    const response = await $fetch(`members/password-reset`, {
+    const response = await useAuthDataFetch(`members/password-reset`, {
       baseURL: `${config.public.apiBase}`,
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json'
+        "Content-Type": "application/json",
       },
       body: {
         email: resetInfo.value.email,
         token: key.value,
-        newPassword: resetInfo.value.password
-      }
+        newPassword: resetInfo.value.password,
+      },
     });
 
     if (!response) {
@@ -54,59 +52,67 @@ const passwordResetApi = async () => {
 
     console.log("비밀번호 수정 완료");
     router.push("/member/login");
-  } catch (error) {
-  }
+  } catch (error) {}
 };
 
 watchEffect(() => {
   if (emailInfo.value) {
     resetInfo.value.email = emailInfo.value.email;
-    console.log('')
+    console.log("");
   }
 });
 
 // ----------------------- Method ----------------------- //
 
 const submitPasswordReset = () => {
-  
-  if (resetInfo.value.password === '') {
+  if (resetInfo.value.password === "") {
     resetInfo.value.isPasswordValid = false;
-    resetInfo.value.passwordValidateMessage = '비밀번호를 입력해주세요.';
+    resetInfo.value.passwordValidateMessage = "비밀번호를 입력해주세요.";
     return;
   }
 
   // 8~32자
-  if (!(8 <= resetInfo.value.password.length && resetInfo.value.password.length <= 32)) {
+  if (
+    !(
+      8 <= resetInfo.value.password.length &&
+      resetInfo.value.password.length <= 32
+    )
+  ) {
     resetInfo.value.isPasswordValid = false;
-    resetInfo.value.passwordValidateMessage = '비밀번호는 8~32자로 입력해주세요.';
+    resetInfo.value.passwordValidateMessage =
+      "비밀번호는 8~32자로 입력해주세요.";
     return;
   }
 
   // 대소문자 포함, 숫자
   if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(resetInfo.value.password)) {
     resetInfo.value.isPasswordValid = false;
-    resetInfo.value.passwordValidateMessage = '비밀번호는 대소문자, 숫자를 포함해주세요.';
+    resetInfo.value.passwordValidateMessage =
+      "비밀번호는 대소문자, 숫자를 포함해주세요.";
     return;
   }
 
   // 특스문자 1개이상 포함
   if (!/^(?=.*[!@#$%^&*])/.test(resetInfo.value.password)) {
     resetInfo.value.isPasswordValid = false;
-    resetInfo.value.passwordValidateMessage = '비밀번호는 특수문자를 포함해주세요.';
+    resetInfo.value.passwordValidateMessage =
+      "비밀번호는 특수문자를 포함해주세요.";
     return;
   }
 
   resetInfo.value.isPasswordValid = true;
 
-  if (resetInfo.value.passwordCheck === '') {
+  if (resetInfo.value.passwordCheck === "") {
     resetInfo.value.isPasswordCheckValid = false;
-    resetInfo.value.passwordCheckValidateMessage = '비밀번호 확인을 입력해주세요.';
+    resetInfo.value.passwordCheckValidateMessage =
+      "비밀번호 확인을 입력해주세요.";
     return;
   }
 
   if (resetInfo.value.password !== resetInfo.value.passwordCheck) {
     resetInfo.value.isPasswordCheckValid = false;
-    resetInfo.value.passwordCheckValidateMessage = '비밀번호가 일치하지 않습니다.';
+    resetInfo.value.passwordCheckValidateMessage =
+      "비밀번호가 일치하지 않습니다.";
     return;
   } else {
     resetInfo.value.isPasswordCheckValid = true;
@@ -115,35 +121,43 @@ const submitPasswordReset = () => {
   // 회원가입 API 호출
   passwordResetApi();
   // router.push('/member/login');
-}
+};
 
 const inputPassword = (password) => {
   resetInfo.value.password = password.trim();
 
-  if (resetInfo.value.password === '') {
+  if (resetInfo.value.password === "") {
     resetInfo.value.isPasswordValid = false;
-    resetInfo.value.passwordValidateMessage = '비밀번호를 입력해주세요.';
+    resetInfo.value.passwordValidateMessage = "비밀번호를 입력해주세요.";
     return;
   }
 
   // 8~32자
-  if (!(8 <= resetInfo.value.password.length && resetInfo.value.password.length <= 32)) {
+  if (
+    !(
+      8 <= resetInfo.value.password.length &&
+      resetInfo.value.password.length <= 32
+    )
+  ) {
     resetInfo.value.isPasswordValid = false;
-    resetInfo.value.passwordValidateMessage = '비밀번호는 8~32자로 입력해주세요.';
+    resetInfo.value.passwordValidateMessage =
+      "비밀번호는 8~32자로 입력해주세요.";
     return;
   }
 
   // 대소문자 포함, 숫자
   if (!/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/.test(resetInfo.value.password)) {
     resetInfo.value.isPasswordValid = false;
-    resetInfo.value.passwordValidateMessage = '비밀번호는 대소문자, 숫자를 포함해주세요.';
+    resetInfo.value.passwordValidateMessage =
+      "비밀번호는 대소문자, 숫자를 포함해주세요.";
     return;
   }
 
   // 특스문자 1개이상 포함
   if (!/^(?=.*[!@#$%^&*])/.test(resetInfo.value.password)) {
     resetInfo.value.isPasswordValid = false;
-    resetInfo.value.passwordValidateMessage = '비밀번호는 특수문자를 포함해주세요.';
+    resetInfo.value.passwordValidateMessage =
+      "비밀번호는 특수문자를 포함해주세요.";
     return;
   }
 
@@ -154,50 +168,57 @@ const inputPasswordCheck = (passwordCheck) => {
   resetInfo.value.passwordCheck = passwordCheck;
   if (resetInfo.value.password !== resetInfo.value.passwordCheck) {
     resetInfo.value.isPasswordCheckValid = false;
-    resetInfo.value.passwordCheckValidateMessage = '비밀번호가 일치하지 않습니다.';
-  } else
-    resetInfo.value.isPasswordCheckValid = true;
+    resetInfo.value.passwordCheckValidateMessage =
+      "비밀번호가 일치하지 않습니다.";
+  } else resetInfo.value.isPasswordCheckValid = true;
 };
-
 </script>
 
 <template>
   <div class="login-member__join-page-container">
     <TextJoinPageInfo
-        label="비밀번호 변경"
-        info-text="변경할 비밀번호를 입력해 주세요"
+      label="비밀번호 변경"
+      info-text="변경할 비밀번호를 입력해 주세요"
     />
     <form>
       <div class="input-text__bar">
         <label class="input-text__label">
           <span class="input-text__label-text">* 이메일</span>
-          <input class="input-text__input" name="email" disabled :value="resetInfo.email" />
+          <input
+            class="input-text__input"
+            name="email"
+            disabled
+            :value="resetInfo.email"
+          />
         </label>
         <div class="wrong-text-box"></div>
       </div>
       <InputTextBar
-          :data="{
+        :data="{
           label: '*비밀번호',
           name: 'password',
           placeholder: '비밀번호 입력',
           inputType: 'password',
           isValid: resetInfo.isPasswordValid,
-          validateMessage: resetInfo.passwordValidateMessage
+          validateMessage: resetInfo.passwordValidateMessage,
         }"
-          @inputData="inputPassword"
+        @inputData="inputPassword"
       />
       <InputTextBar
-          :data="{
+        :data="{
           label: '*비밀번호 확인',
           name: 'passwordCheck',
           placeholder: '동일한 비밀번호를 입력해주세요',
           inputType: 'password',
           isValid: resetInfo.isPasswordCheckValid,
-          validateMessage: resetInfo.passwordCheckValidateMessage
+          validateMessage: resetInfo.passwordCheckValidateMessage,
         }"
-          @inputData="inputPasswordCheck"
+        @inputData="inputPasswordCheck"
       />
-      <ButtonSubmitBtnFullBar text="비밀번호 변경" @submit="submitPasswordReset" />
+      <ButtonSubmitBtnFullBar
+        text="비밀번호 변경"
+        @submit="submitPasswordReset"
+      />
     </form>
   </div>
 </template>

--- a/frontend-2/pages/memoir/[id]/edit.vue
+++ b/frontend-2/pages/memoir/[id]/edit.vue
@@ -36,7 +36,7 @@ const editPost = async () => {
   memoir.value.text = editor.getHTML();
 
   //fetch
-  const response = await $fetch("memoirs/" + memoirId.value, {
+  const response = await useAuthDataFetch("memoirs/" + memoirId.value, {
     method: "PUT",
     baseURL: `${config.public.apiBase}`,
     body: {
@@ -62,7 +62,7 @@ const editPost = async () => {
   await navigateTo(`/memoir/${memoirId.value}`);
 };
 
-const { data } = await useFetch(`memoirs/${useRoute().params.id}`, {
+const { data } = await useAuthFetch(`memoirs/${useRoute().params.id}`, {
   method: "GET",
   baseURL: `${config.public.apiBase}`,
 });

--- a/frontend-2/pages/memoir/[id]/index.vue
+++ b/frontend-2/pages/memoir/[id]/index.vue
@@ -51,7 +51,7 @@ let book = ref({
 });
 
 //fetch
-const { data, error } = await useFetch(`/memoirs/${useRoute().params.id}`, {
+const { data, error } = await useAuthFetch(`/memoirs/${useRoute().params.id}`, {
   method: "GET",
   baseURL: `${config.public.apiBase}`,
 });
@@ -74,7 +74,7 @@ const memoirItems = ref([]);
 const leafItems = ref([]);
 
 //fetch
-const { data: leafCardData, error: leafCardError } = await useFetch(
+const { data: leafCardData, error: leafCardError } = await useAuthFetch(
   `/members/${member.value.id}/leaves/book/cards`,
   {
     method: "GET",
@@ -82,7 +82,7 @@ const { data: leafCardData, error: leafCardError } = await useFetch(
   }
 );
 
-const { data: treeCardData, error: treeCardError } = await useFetch(
+const { data: treeCardData, error: treeCardError } = await useAuthFetch(
   `trees/members/${member.value.id}/trees/book/cards`,
   {
     method: "GET",
@@ -90,7 +90,7 @@ const { data: treeCardData, error: treeCardError } = await useFetch(
   }
 );
 
-const { data: memoirCardData, error: memoirCardError } = await useFetch(
+const { data: memoirCardData, error: memoirCardError } = await useAuthFetch(
   `memoirs/members/${member.value.id}/memoirs/book/cards`,
   {
     method: "GET",

--- a/frontend-2/pages/memoir/[id]/reg.vue
+++ b/frontend-2/pages/memoir/[id]/reg.vue
@@ -38,7 +38,7 @@ const savePost = async () => {
   memoir.value.text = editor.getHTML();
 
   //useFetch
-  const { data, error } = await useFetch("memoirs/" + treeId, {
+  const { data, error } = await useAuthFetch("memoirs/" + treeId, {
     method: "POST",
     baseURL: `${config.public.apiBase}`,
     headers: {
@@ -65,7 +65,7 @@ const savePost = async () => {
   }
 };
 
-const { data, error } = await useFetch(`books/tree/${treeId}`, {
+const { data, error } = await useAuthFetch(`books/tree/${treeId}`, {
   method: "GET",
   baseURL: `${config.public.apiBase}`,
 });

--- a/frontend-2/pages/tree/[id]/index.vue
+++ b/frontend-2/pages/tree/[id]/index.vue
@@ -66,7 +66,7 @@ const closePopup = () => {
   queryParam.page = 0;
 };
 
-const { data: infoData, error: infoError } = await useFetch(
+const { data: infoData, error: infoError } = await useAuthFetch(
   () => `trees/${treeId}/info`,
   {
     baseURL: config.public.apiBase,
@@ -77,7 +77,7 @@ const {
   data: branchData,
   error: branchError,
   refresh,
-} = await useFetch(() => `trees/${treeId}/branches`, {
+} = await useAuthFetch(() => `trees/${treeId}/branches`, {
   baseURL: config.public.apiBase,
   params: queryParam,
 });

--- a/frontend-2/pages/tree/book/auto/[id]/new.vue
+++ b/frontend-2/pages/tree/book/auto/[id]/new.vue
@@ -1,5 +1,5 @@
 <script setup>
-import {onMounted, ref, watch} from "vue";
+import { onMounted, ref, watch } from "vue";
 import axios, { HttpStatusCode } from "axios";
 import { useRouter } from "#vue-router";
 
@@ -33,7 +33,7 @@ const treeFormData = useState("treeFormData", () => ({
 }));
 
 // ----------------------- API ----------------------- //
-const { data } = await useFetch(`/books/${bookId}/info`, {
+const { data } = await useAuthFetch(`/books/${bookId}/info`, {
   method: "GET",
   baseURL: config.public.apiBase,
   headers: {
@@ -48,7 +48,6 @@ watchEffect(() => {
     treeFormData.value.bookId = data.value.id;
     book.value = data.value;
   }
-
 });
 
 // ----------------------- Life Cycle ----------------------- //

--- a/frontend-2/pages/tree/etc/seed/[id]/new.vue
+++ b/frontend-2/pages/tree/etc/seed/[id]/new.vue
@@ -1,8 +1,8 @@
 <script setup>
-import {onMounted, watch} from "vue";
+import { onMounted, watch } from "vue";
 import axios, { HttpStatusCode } from "axios";
-import {useRouter} from "#vue-router";
-import {value} from "lodash/seq.js";
+import { useRouter } from "#vue-router";
+import { value } from "lodash/seq.js";
 
 // ----------------------- Model ----------------------- //
 const route = useRoute();
@@ -10,7 +10,7 @@ const router = useRouter();
 const config = useRuntimeConfig();
 const seedId = route.params.id;
 
-const treeFormData = useState('treeFormData', () => ({
+const treeFormData = useState("treeFormData", () => ({
   // 트리 씨앗 정보
   seedId: Number(seedId),
 
@@ -35,9 +35,12 @@ watch(treeFormData.value, (newVal) => {
 });
 
 // ----------------------- API ----------------------- //
-const { data: seedData, error: infoError } = await useFetch(() => `seeds/${seedId}`, {
-  baseURL: config.public.apiBase,
-});
+const { data: seedData, error: infoError } = await useAuthFetch(
+  () => `seeds/${seedId}`,
+  {
+    baseURL: config.public.apiBase,
+  }
+);
 
 watchEffect(() => {
   // console.log("seedData:", seedData.value);
@@ -58,7 +61,6 @@ const handleImageSelected = (imageData) => {
 };
 
 const validateCheck = () => {
-
   // 트리 이름 확인
   if (!treeFormData.value.treeTitle) {
     treeFormData.value.treeTitleValid = false;
@@ -84,7 +86,6 @@ const validateCheck = () => {
 };
 
 const submitFormHandler = async (e) => {
-
   // 검증 로직
   if (!validateCheck()) {
     return;
@@ -106,11 +107,11 @@ const submitFormHandler = async (e) => {
     }
 
     const response = await axios.post(
-        "http://localhost:8080/api/v1/trees",
-        treeFormDataToSend,
-        {
-          headers: {"Content-Type": "multipart/form-data"},
-        }
+      "http://localhost:8080/api/v1/trees",
+      treeFormDataToSend,
+      {
+        headers: { "Content-Type": "multipart/form-data" },
+      }
     );
 
     if (response.status !== HttpStatusCode.Created) {
@@ -135,7 +136,6 @@ const inputDescription = (value) => {
   treeFormData.value.description = value;
   treeFormData.value.descriptionValid = true;
 };
-
 </script>
 
 <template>
@@ -152,36 +152,40 @@ const inputDescription = (value) => {
       <h1 class="none">도서 정보 입력</h1>
 
       <section class="select-title-container">
-        <TextMainTitle :data="{ title: `${seedData.name}`, size: 28 }"></TextMainTitle>
+        <TextMainTitle
+          :data="{ title: `${seedData.name}`, size: 28 }"
+        ></TextMainTitle>
       </section>
 
       <form class="book-tree-input-form">
         <section class="none">
           <h1 class="none">씨앗 카테고리</h1>
           <input
-              type="number"
-              name="seedCategoryId"
-              v-model="treeFormData.seedId"
+            type="number"
+            name="seedCategoryId"
+            v-model="treeFormData.seedId"
           />
         </section>
 
         <section class="book-tree-input-form__photo-container">
           <h1 class="none">트리 이미지 입력</h1>
-          <InputBookInputImg @image-selected="handleImageSelected"></InputBookInputImg>
+          <InputBookInputImg
+            @image-selected="handleImageSelected"
+          ></InputBookInputImg>
         </section>
 
         <section class="input-form__input-container">
           <h1 class="none">트리이름 입력</h1>
           <InputTextBox
-              :data="{
-                label: '*트리 이름',
-                name: 'treeTitle',
-                placeholder: '트리 이름을 입력해주세요',
-                value: treeFormData.treeTitle,
-                validate: treeFormData.treeTitleValid,
-                validateMessage: '트리 이름을 입력해주세요.'
-              }"
-              @inputData="inputTreeTitle"
+            :data="{
+              label: '*트리 이름',
+              name: 'treeTitle',
+              placeholder: '트리 이름을 입력해주세요',
+              value: treeFormData.treeTitle,
+              validate: treeFormData.treeTitleValid,
+              validateMessage: '트리 이름을 입력해주세요.',
+            }"
+            @inputData="inputTreeTitle"
           >
           </InputTextBox>
         </section>
@@ -189,29 +193,32 @@ const inputDescription = (value) => {
         <section class="book-tree-input-form__large-input-container">
           <h1 class="none">설명글 or URL</h1>
           <InputTextareaBox
-              :data="{
-                label: '*설명글 or URL',
-                name: 'description',
-                placeholder: '트리에 대한 설명을 입력해주세요',
-                value: treeFormData.description,
-                validate: treeFormData.descriptionValid,
-                validateMessage: '트리에 대한 설명을 입력해주세요.'
-              }"
-              @inputData="inputDescription"
+            :data="{
+              label: '*설명글 or URL',
+              name: 'description',
+              placeholder: '트리에 대한 설명을 입력해주세요',
+              value: treeFormData.description,
+              validate: treeFormData.descriptionValid,
+              validateMessage: '트리에 대한 설명을 입력해주세요.',
+            }"
+            @inputData="inputDescription"
           >
           </InputTextareaBox>
         </section>
 
         <section class="input-form__input-container">
           <h1 class="none">공개성 선택</h1>
-          <InputVisibility name="visibility" v-model="treeFormData.visibility"></InputVisibility>
+          <InputVisibility
+            name="visibility"
+            v-model="treeFormData.visibility"
+          ></InputVisibility>
         </section>
 
         <section class="book-tree-submit-container">
           <h1 class="none">트리 생성 버튼</h1>
           <ButtonSubmitBtnFullBar
-              text="트리 생성"
-              @click.prevent="submitFormHandler"
+            text="트리 생성"
+            @click.prevent="submitFormHandler"
           ></ButtonSubmitBtnFullBar>
         </section>
       </form>

--- a/frontend-2/plugins/auth-reload.client.js
+++ b/frontend-2/plugins/auth-reload.client.js
@@ -1,0 +1,10 @@
+export default defineNuxtPlugin((Nuxtapp) => {
+  const memberStore = useMemberStore();
+  //1. 새로고침시 로그인 정보를 로컬 스토리지에서 로드
+
+  try {
+    memberStore.loadUserFromStorage();
+  } catch (e) {
+    console.log("loadUserFromStorage error = ", e);
+  }
+});

--- a/frontend-2/plugins/auth-reload.js
+++ b/frontend-2/plugins/auth-reload.js
@@ -1,8 +1,0 @@
-export default defineNuxtPlugin((Nuxtapp) => {
-  const memberDetail = useMemberDetail();
-
-  // 로컬 스토리지에 저장된 사용자 정보 로드
-  if (!import.meta.env.SSR) {
-    memberDetail.loadUserFromStorage();
-  }
-});

--- a/frontend-2/stores/useMemberStore.js
+++ b/frontend-2/stores/useMemberStore.js
@@ -1,7 +1,7 @@
 import { defineStore } from "pinia";
 import { jwtDecode } from "jwt-decode";
 
-export const useMemberDetail = defineStore("ggogitMember", () => {
+export const useMemberStore = defineStore("memberStore", () => {
   const _id = ref("");
   const _username = ref("");
   const _nickname = ref("");
@@ -15,9 +15,7 @@ export const useMemberDetail = defineStore("ggogitMember", () => {
 
   function setAuthWithToken(accessToken) {
     _accessToken.value = accessToken;
-    console.log("accessToken", _accessToken.value);
     const memberInfo = jwtDecode(_accessToken.value);
-    console.log("memberInfo", memberInfo);
     setAuth(memberInfo);
   }
 
@@ -42,19 +40,23 @@ export const useMemberDetail = defineStore("ggogitMember", () => {
     }
   }
 
-  const loadUserFromStorage = () => {
+  function loadUserFromStorage() {
     try {
       if (!import.meta.env.SSR) {
+        if (localStorage.getItem("_ggogit_accessToken") === null) return;
+
         _id.value = localStorage.getItem("_ggogit_id");
         _username.value = localStorage.getItem("_ggogit_username");
         _nickname.value = localStorage.getItem("_ggogit_nickname");
         _email.value = localStorage.getItem("_ggogit_email");
         _roles.value = JSON.parse(localStorage.getItem("_ggogit_roles"));
+        _accessToken.value = localStorage.getItem("_ggogit_accessToken");
       }
     } catch (e) {
+      console.log("loadUserFromStorage error = ", e);
       initAuth();
     }
-  };
+  }
 
   function initAuth() {
     _id.value = 0;
@@ -63,6 +65,14 @@ export const useMemberDetail = defineStore("ggogitMember", () => {
     _email.value = "";
     _roles.value = [];
     _accessToken.value = "";
+    if (!import.meta.env.SSR) {
+      localStorage.setItem("_ggogit_id", _id.value);
+      localStorage.setItem("_ggogit_username", _username.value);
+      localStorage.setItem("_ggogit_nickname", _nickname.value);
+      localStorage.setItem("_ggogit_email", _email.value);
+      localStorage.setItem("_ggogit_roles", JSON.stringify(_roles.value));
+      localStorage.setItem("_ggogit_accessToken", _accessToken.value);
+    }
   }
 
   function hasRole(role) {
@@ -73,13 +83,19 @@ export const useMemberDetail = defineStore("ggogitMember", () => {
   }
 
   return {
+    _id,
+    _username,
+    _nickname,
+    _email,
+    _roles,
+    _accessToken,
     setAuthWithToken,
     getAuthToken,
     isAnonymous,
     hasRole,
     setAuth,
+    loadUserFromStorage,
     initAuth,
     setEmail,
-    loadUserFromStorage,
   };
 });


### PR DESCRIPTION
## 상태유지를 위해 `stores/useMemberStore.js` 를 추가했습니다.
- 새로고침해도 member의 상태(로그인 등)를 유지하도록 했습니다.

### 유지되는 상태를 통해 로그인되지 않은 상태라면 `members/login` 으로 리다이렉션시켰습니다.
- 이 과정에서 새로 알게된 사실이 있습니다. Nuxt의 라우터 미들웨어에서 pinia를 이용하려면 CSR에서만 제대로 동작하는 듯 합니다.. Nuxt의 생명주기에 대해 더 공부해야할 것 같습니다.

### 로그아웃을 구현했습니다.

### Fetch를 커스텀으로 두가지 구현하고 모두 교체했습니다. 둘 다 로컬스토리지 내에 있는 토큰을 추가합니다.
- `useAuthFetch` 는 기존 `useFetch` 를 대체합니다.
- `useAuthDataFetch`는 기존 `$fetch` 를 대체합니다.

**`useAuthFetch` 사용시, 새로고침하면 데이터를 불러오지 않는 현상이 있었습니다.** 고민해보니... 새로고침시 SSR단계에서 useFetch가 일어나는데, 로컬 스토리지는 SSR단계에서 접근할 수 없어서 토큰을 획득할 수 없고, 그래서 빈 값들이 반환되고 있었습니다. 이에 `useAuthFetch` 는 SSR과 CSR에서 한번씩 총 두번 호출하도록 설계했습니다.

![image](https://github.com/user-attachments/assets/50f7df02-fe79-41c9-9470-4f1d5aa3b51d)

이로 인해 새로고침시 SSR에서 비어있던 데이터를 CSR에서 채우느라 살짝 깜빡이는 현상이 생겼습니다. 추후에 수정하겠습니다.