### PR TITLE
Fix/ #293 전반적인 기타 트리 조회 로직 개선, 홈 화면 트리 fetch 버그 수정

### DIFF
--- a/backend-2/src/main/java/io/ggogit/ggogit/api/leaf/dto/LeafBookCardResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/leaf/dto/LeafBookCardResponse.java
@@ -47,6 +47,7 @@ public class LeafBookCardResponse {
         // 카드 타입
         @Builder.Default
         int cardType = 2;
+        Long leafId;
         // 도서 카테고리
         String bookCategory;
         // 도서 제목
@@ -82,6 +83,7 @@ public class LeafBookCardResponse {
 
             return ItemDto.builder()
                     .cardType(2)
+                    .leafId(leaf.getId())
                     .bookCategory(bookCategory.getName())
                     .bookTitle(book.getTitle())
                     .cardImage(book.getImageFile())
@@ -103,6 +105,8 @@ public class LeafBookCardResponse {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy-MM-dd HH:mm");
 
             return ItemDto.builder()
+                    .cardType(2)
+                    .leafId(leaf.getId())
                     .bookCategory(null)
                     .bookTitle(null)
                     .cardImage(null)

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/memoir/MemoirController.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/memoir/MemoirController.java
@@ -126,6 +126,7 @@ public class MemoirController {
     //MemoirBookCard 조회 (회고록, 리프 디테일)
     @GetMapping("members/{memberId}/memoirs/book/cards")
     public ResponseEntity<MemoirBookCardDtoResponseList> getMemoirCards(@PathVariable(name="memberId") Long memberId) {
+
         MemoirBookCardDtoResponseList memoirBookCardDtoResponseList = memoirDtoService.getMemoirBookCardDtoResponseList(memberId);
         return new ResponseEntity<>(memoirBookCardDtoResponseList, HttpStatus.OK);
     }

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/memoir/dto/MemoirBookCardDtoResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/memoir/dto/MemoirBookCardDtoResponse.java
@@ -17,6 +17,7 @@ public class MemoirBookCardDtoResponse {
     @Builder.Default
     private int cardType = 1;
     //회고록
+    private Long memoirId;
     private String memoirTitle;
     private String updateTime;
     private Boolean visibility;
@@ -48,6 +49,7 @@ public class MemoirBookCardDtoResponse {
     public static MemoirBookCardDtoResponse of(Memoir memoir, Tree tree) {
         return MemoirBookCardDtoResponse.builder()
                 .cardType(1)
+                .memoirId(memoir.getId())
                 .memoirTitle(memoir.getTitle())
                 .updateTime(MemoirBookCardDtoResponse.changeUpdateTime(memoir.getUpdateTime()))
                 .visibility(memoir.getVisibility())

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/memoir/dto/MemoirBookCardDtoResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/memoir/dto/MemoirBookCardDtoResponse.java
@@ -32,7 +32,7 @@ public class MemoirBookCardDtoResponse {
     private String bookPublishedYear;
 
     //조회수, 리프
-    private Long views;
+    private Long viewCount;
     private Long leafCount;
 
     public static String changeBookPublishedYear(LocalDate bookPublishedYear) {

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
@@ -267,11 +267,11 @@ public class TreeController {
         Pageable pageable = PageRequest.of(offset, limit, sort);
 
         List<Tree> allByMemberId = treeService.findAllPages(memberId, pageable).getContent();
-        List<TreeBookCardResponse> treeBookCardRespons = allByMemberId.stream()
+        List<TreeBookCardResponse> treeBookCardResponse = allByMemberId.stream()
                 .map(tree -> TreeBookCardResponse.toEntity(tree.getBook(), true, tree, tree.getSeed(), memberId))
                 .toList();
 
-        return new ResponseEntity<>(TreeBookCardResponseList.of(treeBookCardRespons), HttpStatus.OK);
+        return new ResponseEntity<>(TreeBookCardResponseList.of(treeBookCardResponse), HttpStatus.OK);
     }
 
     @GetMapping("members/{memberId}/books/{bookId}/trees/cards")

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeBookCardResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeBookCardResponse.java
@@ -22,6 +22,7 @@ import java.time.format.DateTimeFormatter;
 public class TreeBookCardResponse {
     @Builder.Default
     private int cardType = 0;
+    private Long treeId;
     private String bookCategory;
     private String bookTitle;
     private String bookAuthor;
@@ -46,6 +47,7 @@ public class TreeBookCardResponse {
         if(book == null){
             return TreeBookCardResponse.builder()
                     .cardType(0)
+                    .treeId(tree.getId())
                     .cardImage(tree.getTreeImage().getName())
                     .seedKorName(Seed.getKorName())
                     .leafCount((long) tree.getLeaf().size())
@@ -59,6 +61,7 @@ public class TreeBookCardResponse {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy");
         return TreeBookCardResponse.builder()
                 .cardType(0)
+                .treeId(tree.getId())
                 .bookCategory(book.getBookCategory().getName())
                 .bookTitle(book.getTitle())
                 .bookAuthor(book.getAuthor())

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeBookCardResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeBookCardResponse.java
@@ -43,6 +43,18 @@ public class TreeBookCardResponse {
     }
 
     public static TreeBookCardResponse toEntity(Book book, boolean isCompletedBook, Tree tree, Seed Seed, Long memberId){
+        if(book == null){
+            return TreeBookCardResponse.builder()
+                    .cardType(0)
+                    .cardImage(tree.getTreeImage().getName())
+                    .seedKorName(Seed.getKorName())
+                    .leafCount((long) tree.getLeaf().size())
+                    .viewCount((long) tree.getLeaf().stream().mapToInt(Leaf::getViewCount).sum())
+                    .treeTitle(tree.getTitle())
+                    .visibility(tree.getVisibility())
+                    .updateTime(TreeBookCardResponse.changeUpdateTime(tree.getUpdateTime()))
+                    .build();
+        }
         LocalDate publishYear = book.getPublishDate();
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy");
         return TreeBookCardResponse.builder()

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeInfoResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeInfoResponse.java
@@ -23,6 +23,7 @@ public class TreeInfoResponse {
     private String bookPublisher;
     private String bookPublishedYear;
     private Integer bookTotalPage;
+    private String coverImageName;
     //relationship identifiers
     private Long treeId;
     private Long memberId ;
@@ -34,7 +35,7 @@ public class TreeInfoResponse {
     private String  leafCreatedAt;
     private String  createdAt;
     private Integer readingPage ;
-    private String coverImageName;
+    private String treeImage;
     //computed
     private Long treeLeafCnt;
     private Long treeLikeCnt;
@@ -59,6 +60,7 @@ public class TreeInfoResponse {
                 .createdAt(tree.getCreateTime().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
                 .leafCreatedAt(latestLeafDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))
                 .readingPage(tree.getTreeBook() == null ? null : tree.getTreeBook().getReadingPage())//tree.getTreeBook().getReadingPage())
+                .treeImage(tree.getTreeImage() == null ? null : tree.getTreeImage().getName())
                 .coverImageName(tree.getBook() == null ? null : tree.getBook().getImageFile())
                 .treeLeafCnt(leafCnt)
                 .treeLikeCnt(likeCnt)

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeInfoResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeInfoResponse.java
@@ -28,6 +28,7 @@ public class TreeInfoResponse {
     private Long treeId;
     private Long memberId ;
     private Long seedId;
+    private String seedKorName;
     //trees
     private String title;
     private String description;
@@ -54,6 +55,7 @@ public class TreeInfoResponse {
                 .treeId(tree.getId())
                 .memberId(tree.getMember().getId())
                 .seedId(tree.getSeed().getId())
+                .seedKorName(tree.getSeed().getKorName())
                 .title(tree.getTitle())
                 .description(tree.getDescription())
                 .visibility(tree.getVisibility())

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/memoir/service/MemoirDtoServiceImpl.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/memoir/service/MemoirDtoServiceImpl.java
@@ -30,16 +30,18 @@ public class MemoirDtoServiceImpl implements MemoirDtoService {
         Pageable pageable = PageRequest.of(offset, limit, sort);
 
         List<Tree> trees = treeRepository.findTreeByMemberIdFetch(memberId, pageable).getContent();
-        List<MemoirBookCardDtoResponse> memoirBookCardDtoRespons = trees.stream().filter(tree -> tree.getMemoir() != null)
+        List<MemoirBookCardDtoResponse> memoirBookCardDtoResponse = trees.stream().filter(tree -> tree.getMemoir() != null)
                 .map(tree -> {
                     MemoirBookCardDtoResponse dto = MemoirBookCardDtoResponse.of(tree.getMemoir(), tree);
                     long leafNum = tree.getLeaf().stream().count();
                     dto.setLeafCount(leafNum);
+                    //TODO: 조회수 임시 하드코딩
+                    dto.setViewCount(10L);
                     return dto;
                 }
                 ).toList();
 
-        return MemoirBookCardDtoResponseList.of(memoirBookCardDtoRespons);
+        return MemoirBookCardDtoResponseList.of(memoirBookCardDtoResponse);
     }
 
     @Override

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
@@ -75,10 +75,11 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
                 .selectFrom(tree)
 //                .join(tree.leaf, leaf).fetchJoin()
 //                .join(tree.book.bookCategory, bookCategory).fetchJoin()
-                .join(tree.seed, seed).on(seedEq(seedId))
+                .join(tree.seed, seed).fetchJoin()
                 .join(tree.book, book).fetchJoin()
                 .join(tree.treeBook, treeBook).fetchJoin()
                 .join(tree.member, member).on(memberEq(memberId))
+                .where(seedEq(seedId))
                 .fetch();
     }
 

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
@@ -34,6 +34,7 @@ import static io.ggogit.ggogit.domain.memoir.entity.QMemoir.memoir;
 import static io.ggogit.ggogit.domain.tree.entity.QSeed.seed;
 import static io.ggogit.ggogit.domain.tree.entity.QTree.tree;
 import static io.ggogit.ggogit.domain.tree.entity.QTreeBook.treeBook;
+import static io.ggogit.ggogit.domain.tree.entity.QTreeImage.treeImage;
 
 @RequiredArgsConstructor
 @Repository
@@ -75,11 +76,11 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
                 .selectFrom(tree)
 //                .join(tree.leaf, leaf).fetchJoin()
 //                .join(tree.book.bookCategory, bookCategory).fetchJoin()
-                .join(tree.seed, seed).fetchJoin()
-                .join(tree.book, book).fetchJoin()
-                .join(tree.treeBook, treeBook).fetchJoin()
                 .join(tree.member, member).on(memberEq(memberId))
-                .where(seedEq(seedId))
+                .join(tree.seed, seed).on(seedEq(seedId))
+                .leftJoin(tree.book, book).fetchJoin()
+                .leftJoin(tree.treeBook, treeBook).fetchJoin()
+                .leftJoin(tree.treeImage, treeImage).fetchJoin()
                 .fetch();
     }
 
@@ -89,8 +90,9 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
                 .selectFrom(tree)
 //                .join(tree.leaf, leaf).fetchJoin()
 //                .join(tree.book.bookCategory, bookCategory).fetchJoin()
-                .join(tree.book, book).fetchJoin()
-                .join(tree.treeBook, treeBook).fetchJoin()
+                .leftJoin(tree.book, book).fetchJoin()
+                .leftJoin(tree.treeBook, treeBook).fetchJoin()
+                .leftJoin(tree.treeImage, treeImage).fetchJoin()
                 .join(tree.member, member).fetchJoin()
                 .where(memberEq(memberId))
                 .offset(pageable.getOffset())

--- a/frontend-2/components/bar/LeafReadingPageInfo.vue
+++ b/frontend-2/components/bar/LeafReadingPageInfo.vue
@@ -1,23 +1,22 @@
 <script setup>
-const { data } = defineProps(['data']);
+const { data } = defineProps(["data"]);
 </script>
 
 <template>
   <div class="leaf-page-info-box">
-    <h1 class="text-main-title" :class="`text--title${ data.size }`">
+    <h1 class="text-main-title" :class="`text--title${data.size}`">
       {{ data.title }}
     </h1>
     <p class="leaf-page-info-box__text">
       <span class="leaf-page-info-box__start_page">{{ data.startPage }}</span>
-      ~
+      <span> ~ </span>
       <span class="leaf-page-info-box__end_page">{{ data.endPage }}</span>
-      p
+      쪽
     </p>
   </div>
 </template>
 
 <style scoped>
-
 .leaf-page-info-box {
   width: 100%;
   display: flex;

--- a/frontend-2/components/card/CardAnotherRecords.vue
+++ b/frontend-2/components/card/CardAnotherRecords.vue
@@ -13,13 +13,27 @@ const item = props.item;
 function modifyCount(count: number) {
   return count > 999 ? "999+" : String(count);
 }
+
+const link = () => {
+  if (item.cardType === CardType.TREE) {
+    return `/tree/${item.treeId}`;
+  } else if (item.cardType === CardType.MEMOIR) {
+    return `/memoir/${item.memoirId}`;
+  } else if (item.cardType === CardType.LEAF) {
+    if (item.bookTitle) {
+      return `/leaf/book/${item.leafId}`;
+    } else {
+      return `/leaf/etc/${item.leafId}`;
+    }
+  }
+};
 </script>
 
 <template>
   <!-- (item, type) -->
   <div class="card-another-records-box">
     <div class="card-another-records__top-box">
-      <a class="card-another-records__top-anker" href="">
+      <NuxtLink class="card-another-records__top-anker" :to="link()">
         <!-- 표지 -->
         <div v-if="item.cardType === CardType.TREE">
           <img
@@ -90,7 +104,7 @@ function modifyCount(count: number) {
             }}</span>
           </div>
         </div>
-      </a>
+      </NuxtLink>
       <div class="card-another-records__icon-box">
         <div class="card-another-records__share-icon-box">
           <img src="/public/svg/comment.svg" alt="댓글 아이콘" />

--- a/frontend-2/components/card/CardAnotherRecords.vue
+++ b/frontend-2/components/card/CardAnotherRecords.vue
@@ -38,7 +38,11 @@ function modifyCount(count: number) {
         <div v-else-if="item.cardType === CardType.LEAF">
           <img
             class="card-another-records__top-cover-box"
-            :src="useGetImageUrl(item.cardImage, 'leaf')"
+            :src="
+              item.cardImage
+                ? useGetImageUrl(item.cardImage, 'tree')
+                : useGetImageUrl(item.treeImage, 'tree')
+            "
             alt="리프 이미지"
           />
         </div>
@@ -72,7 +76,7 @@ function modifyCount(count: number) {
             {{ item.bookTitle }}
           </p>
 
-          <div class="card-another-records__info">
+          <div v-if="item.bookPublishedYear" class="card-another-records__info">
             <span class="card-another-records__info">{{
               item.bookPublishedYear
             }}</span>

--- a/frontend-2/components/card/CardTreeDetails.vue
+++ b/frontend-2/components/card/CardTreeDetails.vue
@@ -14,58 +14,50 @@ const tree = ref(props.tree);
 <template>
   <!-- th:fragment="card-tree-details(tree)" -->
 
-  <div class="card-tree-details">
-    <NuxtLink class="card-tree-detail" :to="`tree/${tree.treeId}`">
-      <div class="card-tree__img-frame">
-        <img
-          v-if="tree.coverImageName"
-          class="card-tree__book-cover"
-          alt="treeCover"
-          :src="useGetImageUrl(tree.coverImageName)"
-        />
-        <img
-          v-else
-          class="card-tree__book-cover"
-          src="/public/png/tree-icon-white.png"
-          alt="treeCover"
-        />
-      </div>
+  <NuxtLink class="card-tree-detail" :to="`tree/${tree.treeId}`">
+    <div class="card-tree__img-frame">
+      <img
+        class="card-tree__book-cover"
+        alt="treeCover"
+        :src="
+          tree.coverImageName
+            ? useGetImageUrl(tree.coverImageName, 'book')
+            : useGetImageUrl(tree.treeImage, 'tree')
+        "
+      />
+    </div>
 
-      <div class="card-tree-detail__box">
-        <!--반복문으로 넣어야 할듯..-->
-        <div class="card-tree-detail__tags">
-          <span class="card-tree-detail__tag">{{ tree.bookCategory }}</span>
-        </div>
-        <!---->
-        <div class="card-tree-detail__slot">
-          <p class="card-tree-detail__name">{{ tree.bookTitle }}</p>
-          <div
-            v-if="tree.bookComplete"
-            class="card-tree-detail__complete-icon"
-          ></div>
-        </div>
-        <p class="card-tree-detail__explanation">{{ tree.treeTitle }}</p>
-        <div class="card-tree-detail__info">
-          <span class="card-tree-detail__info">{{
-            tree.bookPublishedYear
-          }}</span>
-          <span class="card-tree-detail__info"> / </span>
-          <span class="card-tree-detail__info">{{ tree.bookAuthor }}</span>
-          <span class="card-tree-detail__info"> / </span>
-          <span v-if="tree.bookTranslator" class="card-tree-detail__info">{{
-            tree.bookTranslator
-          }}</span>
-          <span class="card-tree-detail__info" v-if="tree.bookTranslator"
-            >/</span
-          >
-          <span class="card-tree-detail__info">{{ tree.bookPublisher }}</span>
-        </div>
-        <span class="card-tree-detail__info-created-date">{{
-          tree.leafCreatedAt
-        }}</span>
+    <div class="card-tree-detail__box">
+      <!--반복문으로 넣어야 할듯..-->
+      <div v-if="tree.bookCategory" class="card-tree-detail__tags">
+        <span class="card-tree-detail__tag">{{ tree.bookCategory }}</span>
       </div>
-    </NuxtLink>
-  </div>
+      <!---->
+      <p class="card-tree-detail__name">{{ tree.title }}</p>
+
+      <div v-if="tree.bookTitle" class="card-tree-detail__slot">
+        <p class="card-tree-detail__explanation">{{ tree.bookTitle }}</p>
+        <div
+          v-if="tree.bookComplete"
+          class="card-tree-detail__complete-icon"
+        ></div>
+      </div>
+      <div v-if="tree.bookPublishedYear" class="card-tree-detail__info">
+        <span class="card-tree-detail__info">{{ tree.bookPublishedYear }}</span>
+        <span class="card-tree-detail__info"> / </span>
+        <span class="card-tree-detail__info">{{ tree.bookAuthor }}</span>
+        <span class="card-tree-detail__info"> / </span>
+        <span v-if="tree.bookTranslator" class="card-tree-detail__info">{{
+          tree.bookTranslator
+        }}</span>
+        <span class="card-tree-detail__info" v-if="tree.bookTranslator">/</span>
+        <span class="card-tree-detail__info">{{ tree.bookPublisher }}</span>
+      </div>
+      <span class="card-tree-detail__info-created-date">{{
+        tree.leafCreatedAt
+      }}</span>
+    </div>
+  </NuxtLink>
 </template>
 
 <style scoped>

--- a/frontend-2/components/card/CardTreeInfoCover.vue
+++ b/frontend-2/components/card/CardTreeInfoCover.vue
@@ -1,38 +1,25 @@
 <script setup>
 const { data } = defineProps(["data"]);
-
-const img = ref(false);
-
-onMounted(async () => {
-  if (data.coverImageName) {
-    img.value = true;
-  }
-});
 </script>
 
 <template>
-  <client-only>
-    <div class="card-tree-info-cover-frame">
-      <div class="card-tree-info-cover">
-        <img
-          v-if="img"
-          class="card-tree-info-cover"
-          :src="useGetImageUrl(data.coverImageName)"
-          alt="cover"
-        />
-        <img
-          v-else
-          class="card-tree-info-cover"
-          :src="`/png/tree-icon-white.png`"
-          alt="cover"
-        />
-      </div>
-      <div class="card-tree-title-frame">
-        <p class="card-tree-title">{{ data.title }}</p>
-        <p class="card-book-title">{{ data.bookTitle }}</p>
-      </div>
+  <div class="card-tree-info-cover-frame">
+    <div class="card-tree-info-cover">
+      <img
+        class="card-tree-info-cover"
+        :src="
+          data.coverImageName
+            ? useGetImageUrl(data.coverImageName, 'book')
+            : useGetImageUrl(data.treeImage, 'tree')
+        "
+        alt="cover"
+      />
     </div>
-  </client-only>
+    <div class="card-tree-title-frame">
+      <p v-if="data.bookTitle" class="card-book-title">{{ data.bookTitle }}</p>
+      <p v-if="data.title" class="card-tree-title">{{ data.title }}</p>
+    </div>
+  </div>
 </template>
 
 <style scoped>
@@ -59,6 +46,7 @@ onMounted(async () => {
   font-weight: var(--bold);
   line-height: var(--line-height-main);
   letter-spacing: var(--letter-spacing-main);
+  padding-bottom: 10px;
 }
 .card-tree-title-frame {
   padding-left: 5px;

--- a/frontend-2/components/card/CardTreePreviews.vue
+++ b/frontend-2/components/card/CardTreePreviews.vue
@@ -16,7 +16,7 @@ const props = defineProps({
     bookAuthor: "",
     bookTranslator: "",
     bookPublisher: "",
-    bookPublishedYear: ""
+    bookPublishedYear: "",
   },
 });
 
@@ -26,11 +26,11 @@ const formatDate = (date) => {
     month: "2-digit", // '10' 형식으로 출력
     day: "2-digit", // '01' 형식으로 출력
     hour: "2-digit",
-    hour12: false,// 시간 출력 (24시간제)
+    hour12: false, // 시간 출력 (24시간제)
     minute: "2-digit", // 분 출력
-    timeZone: "Asia/Seoul" // 한국 시간대
+    timeZone: "Asia/Seoul", // 한국 시간대
   };
-  return new Date(date).toLocaleString('ko-KR', options);
+  return new Date(date).toLocaleString("ko-KR", options);
 };
 const formatYear = (date) => {
   return new Date(date).getFullYear();
@@ -43,7 +43,7 @@ const formatYear = (date) => {
       <img
         v-if="props.data.coverImageName !== ''"
         class="card-tree__book-cover"
-        :src="`/png/${props.data.coverImageName}`"
+        :src="useGetImageUrl(props.data.coverImageName)"
         alt="도서 이미지"
       />
       <img
@@ -54,19 +54,29 @@ const formatYear = (date) => {
       />
       <div class="card-tree-detail__box">
         <div class="card-tree-detail__tags">
-          <span class="card-tree-detail__tag">{{ props.data.seedKorName }}</span>
-          <span class="card-tree-detail__tag">{{ props.data.bookCategory }}</span>
+          <span class="card-tree-detail__tag">{{
+            props.data.seedKorName
+          }}</span>
+          <span class="card-tree-detail__tag">{{
+            props.data.bookCategory
+          }}</span>
         </div>
 
         <!---->
         <p class="card-tree-detail__name">{{ props.data.treeTitle }}</p>
         <p class="card-tree-detail__info">{{ props.data.bookTitle }}</p>
         <div class="card-tree-detail__info">
-          <span class="card-tree-detail__info">{{formatYear(props.data.bookPublishedYear)}}</span>
+          <span class="card-tree-detail__info">{{
+            formatYear(props.data.bookPublishedYear)
+          }}</span>
           <span class="card-tree-detail__info"> &nbsp; </span>
-          <span class="card-tree-detail__info">{{ props.data.bookAuthor }}</span>
+          <span class="card-tree-detail__info">{{
+            props.data.bookAuthor
+          }}</span>
           <span class="card-tree-detail__info"> &nbsp; </span>
-          <span class="card-tree-detail__info">{{ props.data.bookPublisher }}</span>
+          <span class="card-tree-detail__info">{{
+            props.data.bookPublisher
+          }}</span>
         </div>
         <div class="card-tree-detail__info-created-date">
           {{ formatDate(props.data.treeCreatedAt) }}

--- a/frontend-2/components/header/HeaderSearchLink.vue
+++ b/frontend-2/components/header/HeaderSearchLink.vue
@@ -1,9 +1,13 @@
-<script setup></script>
+<script setup>
+const props = defineProps({
+  link: "/tree/book/search",
+});
+</script>
 
 <template>
   <!-- header-search-link -->
   <div class="header-search-link">
-    <router-link class="header-search-link__link" to="/tree/book/search">
+    <NuxtLink class="header-search-link__link" :to="props.link">
       <div class="header-search-link__input-box">
         <p class="header-search-link__placeholder">나의 트리 검색</p>
         <img
@@ -12,7 +16,7 @@
           alt="lens.svg"
         />
       </div>
-    </router-link>
+    </NuxtLink>
   </div>
 </template>
 

--- a/frontend-2/components/text/RecentTreeInfo.vue
+++ b/frontend-2/components/text/RecentTreeInfo.vue
@@ -30,8 +30,8 @@ const formatDate = (date) => {
       <h2 class="textbox-recent-tree-info__tree-title">
         {{ tree.title }}
       </h2>
-      <div v-if="tree.bookCategory" class="textbox-recent-tree-info__tag tag">
-        {{ tree.bookCategory }}
+      <div class="textbox-recent-tree-info__tag tag">
+        {{ tree.bookCategory || tree.seedKorName }}
       </div>
       <p v-if="tree.bookTitle" class="textbox-recent-tree-info__book-title">
         {{ tree.bookTitle }}
@@ -67,7 +67,7 @@ const formatDate = (date) => {
 }
 
 .tag {
-  font-size: 10px;
+  font-size: 15px;
   color: var(--white);
   background-color: var(--main1);
   border-radius: 4px;

--- a/frontend-2/components/text/RecentTreeInfo.vue
+++ b/frontend-2/components/text/RecentTreeInfo.vue
@@ -30,13 +30,13 @@ const formatDate = (date) => {
       <h2 class="textbox-recent-tree-info__tree-title">
         {{ tree.title }}
       </h2>
-      <div class="textbox-recent-tree-info__tag tag">
+      <div v-if="tree.bookCategory" class="textbox-recent-tree-info__tag tag">
         {{ tree.bookCategory }}
       </div>
-      <p class="textbox-recent-tree-info__book-title">
+      <p v-if="tree.bookTitle" class="textbox-recent-tree-info__book-title">
         {{ tree.bookTitle }}
       </p>
-      <div class="textbox-recent-tree-info__items">
+      <div v-if="tree.bookAuthor" class="textbox-recent-tree-info__items">
         <p class="textbox-recent-tree-info__author">{{ tree.bookAuthor }}</p>
         <p class="textbox-recent-tree-info__publisher">
           {{ tree.bookPublisher }}
@@ -85,7 +85,7 @@ const formatDate = (date) => {
 .textbox-recent-tree-info__tree-title {
   order: 1;
   margin-bottom: 4px;
-  font-size: 18px;
+  font-size: 20px;
   font-weight: var(--semi-bold);
   color: var(--main1);
   line-height: var(--line-height-main);

--- a/frontend-2/components/text/TextBookInfoNoTitle.vue
+++ b/frontend-2/components/text/TextBookInfoNoTitle.vue
@@ -24,7 +24,7 @@ let seed = seedConverter(data.seed);
   <!-- text-book-info--no-title(authors,translators, publisher, page,seed) -->
   <div class="text-book-info--no-title">
     <div class="text-book-info--no-title__creators">
-      <div class="text-book-info--no-title__creators">
+      <div v-if="data.authors" class="text-book-info--no-title__creators">
         <span class="text-book-info-create-info">{{ data.authors }} </span>
         <span class="text-book-info-create-info"> | </span>
       </div>
@@ -39,7 +39,9 @@ let seed = seedConverter(data.seed);
       <span class="text-book-info-create-info">{{ data.publisher }}</span>
     </div>
     <div>
-      <span class="text-book-info--no-title__page">총 페이지 수:</span>
+      <span v-if="data.page" class="text-book-info--no-title__page"
+        >총 페이지 수:</span
+      >
       <span class="text-book-info--no-title__page">{{ data.page }}</span>
     </div>
     <div>

--- a/frontend-2/composables/useAuthFetch.js
+++ b/frontend-2/composables/useAuthFetch.js
@@ -31,10 +31,12 @@ export default async function useAuthFetch(url, options = {}) {
   // 3. 사용자가 요청한 url과 option에, 획득한 token을 담아서 fetch 요청하기
   const { data, status, error, refresh } = await useFetch(url, options);
 
-  // //4. CSR에서 한번 더 요청하도록 실행(새로고침 대비)
-  // if (!import.meta.env.SSR) {
-  //   refresh();
-  // }
+  //4. 사용자가 브라우저 종료 후 접속한 경우,
+  //쿠키가 없기 때문에 localStorage의 토큰을 이용해 CSR에서 한번 더 요청
+  if (!import.meta.env.SSR && data.value == null) {
+    console.log("refresh");
+    refresh();
+  }
 
   // 5. fetch의 data, error, status 등을 반환(useFetch와 유사한 형태)
   return { data, error, status, refresh };

--- a/frontend-2/composables/useGetImageUrl.js
+++ b/frontend-2/composables/useGetImageUrl.js
@@ -2,7 +2,7 @@ export default function useGetImageUrl(imageFile = "", imageType = "book") {
   const config = useRuntimeConfig();
 
   if (imageFile === null || imageFile === "" || imageFile === undefined) {
-    return `/png/no-tree-mid-book.png`; // TODO 디폴트 이미지 처리를 해줘야 함
+    return `/png/tree-icon-white.png`; // TODO 디폴트 이미지 처리를 해줘야 함
   }
 
   if (imageFile.substring(0, 4) === "http") {

--- a/frontend-2/pages/home/index.vue
+++ b/frontend-2/pages/home/index.vue
@@ -99,12 +99,6 @@ const bookExRemoveNone = (selectedElement, index) => {
 };
 
 //-------------------LifeCycle-------------------
-onMounted(() => {
-  if (treeInfoList.value.length === 0) {
-    console.log("트리 정보가 없습니다.");
-    treeRefresh();
-  }
-});
 </script>
 
 <template>

--- a/frontend-2/pages/home/index.vue
+++ b/frontend-2/pages/home/index.vue
@@ -112,7 +112,7 @@ onMounted(() => {
     <h1 class="none">나의 트리</h1>
     <section class="header-search-container">
       <h2 class="none">나의 트리 검색 링크</h2>
-      <HeaderSearchLink />
+      <HeaderSearchLink :link="`/tree/search`" />
     </section>
   </header>
 

--- a/frontend-2/pages/home/index.vue
+++ b/frontend-2/pages/home/index.vue
@@ -187,7 +187,11 @@ const bookExRemoveNone = (selectedElement, index) => {
               >
                 <img
                   class="mid__img"
-                  :src="useGetImageUrl(tree.coverImageName)"
+                  :src="
+                    tree.coverImageName
+                      ? useGetImageUrl(tree.coverImageName)
+                      : useGetImageUrl(tree.treeImage, 'tree')
+                  "
                   alt="도서 예시 이미지"
                 />
               </NuxtLink>
@@ -355,6 +359,7 @@ const bookExRemoveNone = (selectedElement, index) => {
   width: 90%;
   height: auto;
   object-fit: cover;
+  border-radius: 10px;
 }
 
 @media screen and (max-width: 768px) {

--- a/frontend-2/pages/tree/search.vue
+++ b/frontend-2/pages/tree/search.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { reactive, ref } from "vue";
 import InputBackSearchTree from "~/components/input/InputBackSearchTree.vue";
-import {debounce} from "lodash";
+import { debounce } from "lodash";
 
 //---------------variable----------------
 const query = ref("");
@@ -12,7 +12,7 @@ const totalCount = ref(0);
 const scrollContainer = ref(null);
 const config = useRuntimeConfig();
 const apiUrl = config.public.apiBase + "/trees/search";
-let filterName = "최근 수정한 순"
+let filterName = "최근 수정한 순";
 let sort = ref(0);
 //-------------handler----------------
 
@@ -56,28 +56,24 @@ const handleScroll = debounce(() => {
   }
 }, 300); // 디바운스 적용으로 스크롤 이벤트 과도한 호출 방지
 const sortHandler = debounce(() => {
-  if(trees.value.length === 0) return;
+  if (trees.value.length === 0) return;
   page.value = 0;
-  if(sort.value === 0)
-    sort.value = 1;
-  else
-    sort.value = 0;
-
+  if (sort.value === 0) sort.value = 1;
+  else sort.value = 0;
 });
-
 
 //-------------life cycle----------------
 onMounted(() => {
   watch(
-      [scrollContainer],
-      () => {
-        if (scrollContainer.value) {
-          scrollContainer.value.addEventListener("scroll", handleScroll, {
-            passive: false,
-          });
-        }
-      },
-      { immediate: true }
+    [scrollContainer],
+    () => {
+      if (scrollContainer.value) {
+        scrollContainer.value.addEventListener("scroll", handleScroll, {
+          passive: false,
+        });
+      }
+    },
+    { immediate: true }
   );
 });
 </script>
@@ -88,22 +84,26 @@ onMounted(() => {
     <section>
       <h2 class="none">트리 검색 창</h2>
       <InputBackSearchTree
-          :placeholder="`검색할 트리를 입력해주세요.`"
-          :href="`./seed/index`"
-          :api="apiUrl"
-          :page="page"
-          :sort="sort"
-          @result="handleTreeResult"
-          @req="handleKeyword"
-          @page="handlePage"
-          @totalCount="handleTotalCount"
-          @totalPage="handleTotalPage"
+        :placeholder="`검색할 트리를 입력해주세요.`"
+        :href="`./seed/index`"
+        :api="apiUrl"
+        :page="page"
+        :sort="sort"
+        @result="handleTreeResult"
+        @req="handleKeyword"
+        @page="handlePage"
+        @totalCount="handleTotalCount"
+        @totalPage="handleTotalPage"
       />
     </section>
 
     <section>
       <h2 class="none">검색 결과 개수 및 최근 수정한 순서</h2>
-      <TopBarSearchResultNumAndFilter :num="totalCount" :filterName="filterName" @sort="sortHandler"/>
+      <TopBarSearchResultNumAndFilter
+        :num="totalCount"
+        :filterName="filterName"
+        @sort="sortHandler"
+      />
     </section>
   </header>
 
@@ -112,8 +112,8 @@ onMounted(() => {
       <div class="text-info-container">
         <h2 class="none">검색 시작 안내</h2>
         <TextInfo
-            :text="'현재 검색중인 트리가 없습니다'"
-            :boldText="'트리를 검색하거나 직접 등록해주세요'"
+          :text="'현재 검색중인 트리가 없습니다'"
+          :boldText="'트리를 검색하거나 직접 등록해주세요'"
         />
       </div>
     </section>
@@ -131,22 +131,11 @@ onMounted(() => {
       <h3 class="none">검색 결과 없음</h3>
       <div class="text-info-container">
         <TextInfo
-            :text="'검색 결과가 없습니다.'"
-            :boldText="'다시 검색하거나 직접 등록해주세요'"
+          :text="'검색 결과가 없습니다.'"
+          :boldText="'다시 검색하거나 직접 등록해주세요'"
         />
       </div>
     </section>
-
-  <section class="btn-select-container--right">
-    <h2 class="none">트리 직접 등록 버튼</h2>
-    <!-- TODO: href변경하기 -->
-    <ButtonBtnShortAGreen
-        :link="`/tree/seed`"
-        :text="`트리 직접 등록하기`"
-    />
-  </section>
-
-
   </main>
   <aside class="nav-container">
     <NavNavigationBar active="home" />

--- a/frontend-2/pages/tree/seed.vue
+++ b/frontend-2/pages/tree/seed.vue
@@ -48,7 +48,10 @@ const filterTabDownHandler = () => {
   <main>
     <section class="text-info-container">
       <h2 class="none">트리 생성 안내</h2>
-      <TextInfo :boldText="`씨앗을 선택해주세요`"></TextInfo>
+      <TextInfo
+        :text="`트리를 생성하기 위해`"
+        :boldText="`씨앗을 선택해주세요`"
+      ></TextInfo>
     </section>
 
     <section class="btn-select-container">

--- a/frontend-2/plugins/auth-reload.client.js
+++ b/frontend-2/plugins/auth-reload.client.js
@@ -3,6 +3,12 @@ export default defineNuxtPlugin((Nuxtapp) => {
   //1. 새로고침시 로그인 정보를 로컬 스토리지에서 로드
   try {
     memberStore.loadUserFromStorage();
+    const tokenCookie = useCookie("_ggogit_accessToken");
+    //쿠키가 없을 경우 리로딩
+    if (tokenCookie.value === undefined) {
+      tokenCookie.value = memberStore.getAuthToken();
+      console.log("tokenCookie.value = ", tokenCookie.value);
+    }
   } catch (e) {
     console.log("loadUserFromStorage error = ", e);
   }

--- a/frontend-2/types/types.ts
+++ b/frontend-2/types/types.ts
@@ -23,6 +23,9 @@ export interface CardItemProps {
   cardImage: string;
   bookCategory: string;
   treeImage?: string;
+  treeId?: number;
+  memoirId?: number;
+  leafId?: number;
 
   /* 도서 정보 경우 경우  */
   bookTitle?: string;

--- a/frontend-2/types/types.ts
+++ b/frontend-2/types/types.ts
@@ -22,6 +22,7 @@ export interface CardItemProps {
   cardType: CardType;
   cardImage: string;
   bookCategory: string;
+  treeImage?: string;
 
   /* 도서 정보 경우 경우  */
   bookTitle?: string;


### PR DESCRIPTION
## 간혹 홈 화면에서 로그인은 유지되지만 트리를 가져오지 못하던 버그를 수정했습니다.
- 이런 일이 생기는 이유는 
1. 로그인을 위한 데이터는 로컬 스토리지에 있어 영구저장되는데, 데이터 패치를 위한 데이터는 세션 쿠키에 있기 때문에
2. 따라서 오랜만에 접속한 유저는 쿠키가 없지만, 로컬 스토리지의 정보는 유지되어 로그인은 되지만 데이터는 불러와지지 않습니다.
3. 이를 해결하기 위해 최초 home화면 로딩시에는 1회 CSR로 데이터를 한번 더 패치하도록 하고, 이후 쿠키에 값을 다시 심어서 다음부터는 SSR로 데이터 패치가 돌아가게끔 했습니다. (최대한 깜빡임 방지용)
4. 그럼에도 위의 버그처럼 보이는 현상이 있는데, 이는 **리소스 서버를 재부팅했을때**입니다. 실제 운영시에는 이런일이 생기지 않겠지만, 개발중에는 빈번히 리소스 서버를 재부팅합니다. 이때 **로그인**을 새로 진행하지 않으면 리소스 서버에는 `userDetail`에 `null`이 들어가있습니다. 따라서 리소스 서버 재부팅 이후에는 **로그인을 다시 진행해줘야 합니다.**
---
## 이제 도서가 없는 트리도 모두 조회됩니다.
- 기존의 쿼리가 `book`과 `tree`의 관계에서 `outer`가 아닌 `innerJoin` 을 수행하고 있었습니다. 따라서 도서가 없는 트리들이 조회가 되지 않는 버그가 있었습니다. 이 부분과 관련된 부분들을 중점으로 쿼리 및 서비스, DTO들을 수정했습니다.
### 기타 트리 출력용 화면 수정
- 위의 바뀐 쿼리로 출력되는 기타 트리들을 바인딩 할 수 있게 앱 전체의 화면을 모두 수정했습니다. 영향받는 페이지는 다음과 같습니다.
1. `/home`의 캐러셀과 트리 목록
2. `/tree/[id]
3. `/leaf/book/leafId`의 카드
4. `/leaf/etc/leafId`의 카드 
5.  `memoir/[id]`의 카드
- 수정한 내용으로는 이미지 출력용 DTO 수정 및 바인딩(BE, FE), 도서 제목, 저자 등이 없을 때의 각 페이지들의 디자인 수정, 카드 경로 바인딩 등이 있습니다. 