### PR TITLE
[fix]홈화면 리스트 텍스트 버그 수정

### DIFF
--- a/frontend-2/components/card/CardTreeDetails.vue
+++ b/frontend-2/components/card/CardTreeDetails.vue
@@ -90,6 +90,8 @@ const tree = ref(props.tree);
   width: 100%;
   line-height: var(--line-height-main);
   letter-spacing: var(--letter-spacing-main);
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .card-tree-detail__tags {


### PR DESCRIPTION
### 홈화면에서 width가 줄어들 경우 트리 리스트의 글자들이 화면을 벗어나던 것을 수정했습니다.