### PR TITLE
[수정] #315 도서 디테일 카드 수정 완료

### DIFF
--- a/backend-2/src/main/java/io/ggogit/ggogit/api/leaf/dto/LeafCardResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/leaf/dto/LeafCardResponse.java
@@ -42,6 +42,8 @@ public class LeafCardResponse {
         @Builder.Default
         int cardType = 2;
 
+        Long id;
+        Long bookId;
         String title;
         String content;
         String updateDate;
@@ -53,6 +55,8 @@ public class LeafCardResponse {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
             return ItemDto.builder()
+                    .id(leaf.getId())
+                    .bookId(tree.getBook().getId())
                     .title(leaf.getTitle())
                     .content(leaf.getContent())
                     .updateDate(leaf.getUpdateTime().format(formatter))

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/memoir/dto/MemoirCardDtoResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/memoir/dto/MemoirCardDtoResponse.java
@@ -58,6 +58,7 @@ public class MemoirCardDtoResponse {
         @Builder.Default
         private int cardType = 1;
 
+        private Long id;
         private String title;
         private String content;
         private String updateDate;
@@ -71,6 +72,7 @@ public class MemoirCardDtoResponse {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
             return itemDto.builder()
+                    .id(memoir.getId())
                     .title(memoir.getTitle())
                     .content(memoir.getText())
                     .updateDate(memoir.getUpdateTime().format(formatter))

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/TreeController.java
@@ -275,22 +275,22 @@ public class TreeController {
         return new ResponseEntity<>(TreeBookCardResponseList.of(treeBookCardResponse), HttpStatus.OK);
     }
 
-    @GetMapping("members/{memberId}/books/{bookId}/trees/cards")
+    @GetMapping("members/books/{bookId}/trees/cards")
     public ResponseEntity<TreeBookCardResponseList> getBookTreeResponse(
-            @PathVariable(name="memberId", required = true) Long memberId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable(name="bookId", required = true) Long bookId){
 
+        Long memberId = userDetails.getId();
         List<Tree> allByBookId = treeService.findAllByBookId(memberId, bookId).getContent();
-        System.out.println("size = " + String.valueOf(allByBookId.size()));
         //해당 책에 멤버가 소유한 트리가 없을 경우
         if(allByBookId.isEmpty()) {
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         }
-        List<TreeBookCardResponse> treeBookCardRespons = allByBookId.stream()
+        List<TreeBookCardResponse> treeBookCardResponse = allByBookId.stream()
                 .map(tree -> TreeBookCardResponse.toEntity(tree.getBook(), true, tree, tree.getSeed(), memberId))
                 .toList();
 
-        return new ResponseEntity<>(TreeBookCardResponseList.of(treeBookCardRespons), HttpStatus.OK);
+        return new ResponseEntity<>(TreeBookCardResponseList.of(treeBookCardResponse), HttpStatus.OK);
     }
 
     @GetMapping("books/{bookId}/trees/cards")

--- a/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeCardDtoResponse.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/api/tree/dto/TreeCardDtoResponse.java
@@ -60,6 +60,7 @@ public class TreeCardDtoResponse {
         @Builder.Default
         private int cardType = 0;
 
+        private Long id;
         private String title;
         private String content;
         private String updateDate;
@@ -73,6 +74,7 @@ public class TreeCardDtoResponse {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
 
             return TreeCardDtoResponse.itemDto.builder()
+                    .id(tree.getId())
                     .title(tree.getTitle())
                     .content(tree.getDescription())
                     .updateDate(tree.getUpdateTime().format(formatter))

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/leaf/repository/LeafQueryDslRepositoryImpl.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/leaf/repository/LeafQueryDslRepositoryImpl.java
@@ -21,7 +21,10 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 import java.util.Optional;
 
+import static io.ggogit.ggogit.domain.book.entity.QBook.book;
 import static io.ggogit.ggogit.domain.leaf.entity.QLeaf.*;
+import static io.ggogit.ggogit.domain.member.entity.QMember.member;
+import static io.ggogit.ggogit.domain.tree.entity.QTree.tree;
 
 @Repository
 @RequiredArgsConstructor
@@ -90,40 +93,14 @@ public class LeafQueryDslRepositoryImpl implements LeafQueryDslRepository {
     public Page<Leaf> getLeafCards(Long bookId, int page, int size) {
 
         QLeaf leaf = QLeaf.leaf;
-        QTree tree = QTree.tree;
-
-        long count = queryFactory
-                .selectFrom(leaf)
-                .where(
-                        leaf.tree.id.in(
-                                JPAExpressions
-                                        .select(tree.id)
-                                        .from(tree)
-                                        .where(
-                                                tree.book.id.eq(bookId),
-                                                tree.isDeleted.eq(false),
-                                                tree.visibility.eq(true)
-                                        )
-                        ),
-                        leaf.isDeleted.eq(false),
-                        leaf.visibility.eq(true)
-                )
-                .fetchCount();
 
         List<Leaf> leaves = queryFactory
                 .selectFrom(leaf)
+                .join(leaf.tree, tree).fetchJoin()
+                .join(tree.member, member).fetchJoin()
+                .join(tree.book, book).fetchJoin()
                 .where(
-                        leaf.tree.id.in(
-                                JPAExpressions
-                                        .select(tree.id)
-                                        .from(tree)
-                                        .where(
-                                                tree.book.id.eq(bookId),
-                                                tree.isDeleted.eq(false),
-                                                tree.visibility.eq(true)
-                                        )
-                        ),
-                        leaf.isDeleted.eq(false),
+                        leaf.tree.book.id.eq(bookId),
                         leaf.visibility.eq(true)
                 )
                 .orderBy(leaf.updateTime.desc())
@@ -131,7 +108,7 @@ public class LeafQueryDslRepositoryImpl implements LeafQueryDslRepository {
                 .limit(size)
                 .fetch();
 
-        return new PageImpl<>(leaves, PageRequest.of(page, size), count);
+        return new PageImpl<>(leaves, PageRequest.of(page, size), leaves.size());
     }
 
     @Override

--- a/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
+++ b/backend-2/src/main/java/io/ggogit/ggogit/domain/tree/repository/query/TreeQueryRepositoryImpl.java
@@ -93,6 +93,7 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
                 .leftJoin(tree.book, book).fetchJoin()
                 .leftJoin(tree.treeBook, treeBook).fetchJoin()
                 .leftJoin(tree.treeImage, treeImage).fetchJoin()
+                .orderBy(tree.updateTime.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -116,6 +117,7 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
                 .leftJoin(tree.book, book).fetchJoin()
                 .leftJoin(tree.treeBook, treeBook).fetchJoin()
                 .leftJoin(tree.treeImage, treeImage).fetchJoin()
+                .orderBy(tree.updateTime.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -140,6 +142,7 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
                 .leftJoin(tree.treeImage, treeImage).fetchJoin()
                 .join(tree.member, member).fetchJoin()
                 .where(memberEq(memberId))
+                .orderBy(tree.updateTime.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -158,6 +161,7 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
                 .join(tree.member, member).on(tree.member.id.eq(member.id))
                 .join(tree.book, book).on(tree.book.id.eq(book.id))
                 .where(memberEq(memberId), bookEq(bookId))
+                .orderBy(tree.updateTime.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -221,11 +225,12 @@ public class TreeQueryRepositoryImpl implements TreeQueryRepository {
 
         List<Tree> result = queryFactory
                 .selectFrom(tree)
-                .join(tree.book, book).fetchJoin()
                 .join(tree.member, member).fetchJoin()
-                .join(tree.treeBook, treeBook).fetchJoin()
-                .join(tree.memoir, memoir).fetchJoin()
+                .leftJoin(tree.book, book).fetchJoin()
+                .leftJoin(tree.treeBook, treeBook).fetchJoin()
+                .leftJoin(tree.memoir, memoir).fetchJoin()
                 .where(bookEq(bookId))
+                .orderBy(tree.updateTime.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/frontend-2/components/card/CardTree.vue
+++ b/frontend-2/components/card/CardTree.vue
@@ -41,25 +41,25 @@ function modifyCount(count: number) {
             <img src="~/assets/svg/like.svg" alt="좋아요 아이콘" />
           </div>
         </div>
-        <div class="card-tree__bot-box">
-          <div class="card-tree__bot-info-box">
-            <p class="card-tree__bot-title">{{ props.data.treeTitle }}</p>
-            <p class="card-tree__bot-date">{{ props.data.updateTime }}</p>
-          </div>
-          <div class="card-tree__bot-statistics-box">
-            <p class="card-tree__bot-leaf-text">
-              <span class="card-tree__bot-leaf-count">{{
-                modifyCount(props.data.leafCount)
-              }}</span>
-              리프
-            </p>
-            <p class="card-tree__bot-view-text">
-              <span class="card-tree__bot-view-count">{{
-                modifyCount(props.data.viewCount)
-              }}</span>
-              조회수
-            </p>
-          </div>
+      </div>
+      <div class="card-tree__bot-box">
+        <div class="card-tree__bot-info-box">
+          <p class="card-tree__bot-title">{{ props.data.treeTitle }}</p>
+          <p class="card-tree__bot-date">{{ props.data.updateTime }}</p>
+        </div>
+        <div class="card-tree__bot-statistics-box">
+          <p class="card-tree__bot-leaf-text">
+            <span class="card-tree__bot-leaf-count">{{
+              modifyCount(props.data.leafCount)
+            }}</span>
+            리프
+          </p>
+          <p class="card-tree__bot-view-text">
+            <span class="card-tree__bot-view-count">{{
+              modifyCount(props.data.viewCount)
+            }}</span>
+            조회수
+          </p>
         </div>
       </div>
     </div>

--- a/frontend-2/components/card/SnsCardTree.vue
+++ b/frontend-2/components/card/SnsCardTree.vue
@@ -19,13 +19,28 @@ const props = defineProps<{
 function modifyCount(count: number) {
   return 999 < count ? "999+" : String(count);
 }
+const link = ref("");
+const getLink = () => {
+  if (props.data.cardType === CardType.TREE) {
+    link.value = `/tree/${props.data.id}`;
+  } else if (props.data.cardType === CardType.MEMOIR) {
+    link.value = `/memoir/${props.data.id}`;
+  } else {
+    if (props.data.bookId) {
+      link.value = `/leaf/book/${props.data.id}`;
+    } else {
+      link.value = `/leaf/etc/${props.data.id}`;
+    }
+  }
+};
+getLink();
 </script>
 
 <template>
   <!-- th:fragment="sns-card-tree(type) -->
   <div class="sns-card-tree-box">
-    <div class="sns-card-tree__top-box">
-      <a href="">
+    <NuxtLink :to="link">
+      <div class="sns-card-tree__top-box">
         <div
           v-if="data.cardType === CardType.TREE"
           class="sns-card-tree__top-tree-icon-box"
@@ -53,17 +68,15 @@ function modifyCount(count: number) {
             alt="리프 아이콘"
           />
         </div>
-      </a>
-      <div class="sns-card-tree__top-sns-icon-box">
-        <div class="sns-card-tree__top-share-icon-box">
-          <img src="~/assets/svg/comment.svg" alt="댓글 아이콘" />
-        </div>
-        <div class="sns-card-tree__top-like-icon-box">
-          <img src="~/assets/svg/like.svg" alt="좋아요 아이콘" />
+        <div class="sns-card-tree__top-sns-icon-box">
+          <div class="sns-card-tree__top-share-icon-box">
+            <img src="~/assets/svg/comment.svg" alt="댓글 아이콘" />
+          </div>
+          <div class="sns-card-tree__top-like-icon-box">
+            <img src="~/assets/svg/like.svg" alt="좋아요 아이콘" />
+          </div>
         </div>
       </div>
-    </div>
-    <a href="">
       <div class="sns-card-tree__mid-box">
         <p class="sns-card-tree__mid-title">{{ data.title }}</p>
         <p class="sns-card-tree__mid-date">{{ data.updateDate }}</p>
@@ -72,43 +85,43 @@ function modifyCount(count: number) {
       <div class="sns-card-tree__memoir-text-box">
         <q class="sns-card-tree-memoir-text">{{ data.content }}</q>
       </div>
-    </a>
-    <div class="sns-card-tree__bot-box">
-      <div class="sns-card-tree__bot-nickname-box">
+      <div class="sns-card-tree__bot-box">
+        <div class="sns-card-tree__bot-nickname-box">
+          <a href="">
+            <p class="sns-card-tree__bot-nickname">
+              <span class="sns-card-tree__bot-nickname-text">{{
+                data.nickname
+              }}</span>
+              <span class="sns-card-tree__bot-nickname-id">{{
+                data.emailId
+              }}</span>
+            </p>
+          </a>
+        </div>
         <a href="">
-          <p class="sns-card-tree__bot-nickname">
-            <span class="sns-card-tree__bot-nickname-text">{{
-              data.nickname
-            }}</span>
-            <span class="sns-card-tree__bot-nickname-id">{{
-              data.emailId
-            }}</span>
-          </p>
+          <div class="sns-card-tree__bot-statistics-box">
+            <p
+              v-if="
+                data.cardType === CardType.MEMOIR ||
+                data.cardType === CardType.TREE
+              "
+              class="sns-card-tree__bot-leaf-text"
+            >
+              <span class="sns-card-tree__bot-leaf-count">{{
+                modifyCount(data.leafCount)
+              }}</span>
+              리프
+            </p>
+            <p class="sns-card-tree__bot-view-text">
+              <span class="sns-card-tree__bot-view-count">{{
+                modifyCount(data.viewCount)
+              }}</span>
+              조회수
+            </p>
+          </div>
         </a>
       </div>
-      <a href="">
-        <div class="sns-card-tree__bot-statistics-box">
-          <p
-            v-if="
-              data.cardType === CardType.MEMOIR ||
-              data.cardType === CardType.TREE
-            "
-            class="sns-card-tree__bot-leaf-text"
-          >
-            <span class="sns-card-tree__bot-leaf-count">{{
-              modifyCount(data.leafCount)
-            }}</span>
-            리프
-          </p>
-          <p class="sns-card-tree__bot-view-text">
-            <span class="sns-card-tree__bot-view-count">{{
-              modifyCount(data.viewCount)
-            }}</span>
-            조회수
-          </p>
-        </div>
-      </a>
-    </div>
+    </NuxtLink>
   </div>
 </template>
 

--- a/frontend-2/pages/book/[id]/index.vue
+++ b/frontend-2/pages/book/[id]/index.vue
@@ -28,19 +28,14 @@ if (bookData.value) {
   book.value = bookData.value;
 }
 
-//TODO: MembmerId는 상태관리 추가되면 가져와야 함 (현재는 임시로 1로 설정)
-const memberId = 1;
 const {
   data: treeCardsData,
   status: treeCardsStatus,
   error: treeCardsError,
-} = await useAuthFetch(
-  `trees/members/${memberId}/books/${bookId}/trees/cards`,
-  {
-    method: "GET",
-    baseURL: `${config.public.apiBase}`,
-  }
-);
+} = await useAuthFetch(`trees/members/books/${bookId}/trees/cards`, {
+  method: "GET",
+  baseURL: `${config.public.apiBase}`,
+});
 
 if (treeCardsData.value) {
   myTreeCards.value = [...treeCardsData.value.treeBookCardResponse];
@@ -61,6 +56,7 @@ const {
 });
 
 if (bookleafCradsData.value) {
+  console.log(bookleafCradsData.value);
   bookleafCards.value = [...bookleafCradsData.value.items];
 }
 
@@ -87,6 +83,7 @@ const {
 });
 
 if (bookTreeCradsData.value) {
+  console.log(bookTreeCradsData.value);
   bookTreeCards.value = [...bookTreeCradsData.value.items];
 }
 </script>
@@ -107,7 +104,7 @@ if (bookTreeCradsData.value) {
           backImgPath: bookData.imageFile,
         }"
       />
-<!--     TODO: 추후에 좋아요 기능 추가시 주석 해제-->
+      <!--     TODO: 추후에 좋아요 기능 추가시 주석 해제-->
       <section class="book-detail-like-bar-container none">
         <h1 class="none">좋아요 및 공유</h1>
         <BarLikeShare
@@ -144,18 +141,18 @@ if (bookTreeCradsData.value) {
       <h1 class="none">도서 기본 정보</h1>
     </section>
 
-    <section class="book-detail-comment-container none">
+    <!-- <section class="book-detail-comment-container none">
       <h1 class="none">댓글</h1>
       <BarComment :commentCount="1" :profileImg="commentCount" />
       <section
         id="comment-filter-tab-id"
         class="book-detail-comment-tab-container book-detail-comment-tab-container--active none"
-      >
-        <h1 class="none">댓글 탭</h1>
-        <!-- TODO: 추후에 데이터 바인딩하면 주석 풀 것 -->
-        <!-- <TabComment /> -->
-      </section>
-    </section>
+      > -->
+    <!-- <h1 class="none">댓글 탭</h1> -->
+    <!-- TODO: 추후에 데이터 바인딩하면 주석 풀 것 -->
+    <!-- <TabComment /> -->
+    <!-- </section>
+    </section> -->
 
     <section class="book-detail-my-tree-container">
       <h1 class="none">도서의 나의 트리 정보</h1>
@@ -164,13 +161,12 @@ if (bookTreeCradsData.value) {
       </section>
 
       <section class="book-detail-my-tree-list-container">
-        <!-- 이 부분은 추후에 어플리케이션이 사용자 정보를 상태 유지 가능할때 기능 추가 할 예정 -->
         <h1 class="none">나의 트리 리스트</h1>
         <section class="book-detail-my-tree-card-container">
           <CardTreeList
-              v-if="myTreeCards.length >= 1"
-              :data="myTreeCards"
-              :sideScrollType="`my-tree`"
+            v-if="myTreeCards.length >= 1"
+            :data="myTreeCards"
+            :sideScrollType="`my-tree`"
           />
           <TextMainTitle
             class="book-detail-my-tree-no-tree-container"
@@ -196,10 +192,7 @@ if (bookTreeCradsData.value) {
       <section class="book-detail-other-tree-list-container">
         <h1 class="none">트리 리스트</h1>
         <section class="book-detail-other-tree-card-container">
-          <CardSnsCardTreeList
-              :list="bookTreeCards"
-              :sideScrollType="`tree`"
-          />
+          <CardSnsCardTreeList :list="bookTreeCards" :sideScrollType="`tree`" />
         </section>
       </section>
 
@@ -211,8 +204,8 @@ if (bookTreeCradsData.value) {
         <h1 class="none">회고록 리스트</h1>
         <section class="book-detail-other-tree-card-container">
           <CardSnsCardTreeList
-              :list="bookMemoirCards"
-              :sideScrollType="`memoir`"
+            :list="bookMemoirCards"
+            :sideScrollType="`memoir`"
           />
         </section>
       </section>
@@ -224,10 +217,7 @@ if (bookTreeCradsData.value) {
       <section class="book-detail-other-tree-list-container">
         <h1 class="none">리프 리스트</h1>
         <section class="book-detail-other-tree-card-container">
-          <CardSnsCardTreeList
-              :list="bookleafCards"
-              :sideScrollType="`leaf`"
-          />
+          <CardSnsCardTreeList :list="bookleafCards" :sideScrollType="`leaf`" />
         </section>
       </section>
     </section>

--- a/frontend-2/stores/useBackStore.js
+++ b/frontend-2/stores/useBackStore.js
@@ -111,10 +111,18 @@ export const useBackStore = defineStore("backStore", () => {
   //쿠키에서 백스택을 불러옵니다.
   //플러그인
   function getStackFromCookie() {
-    backStackForHome.value = backCookieHome.value.split(",");
-    backStackForSearch.value = backCookieSearch.value.split(",");
-    backStackForCommunity.value = backCookieCommunity.value.split(",");
-    backStackForMyPage.value = backCookieMyPage.value.split(",");
+    if (backCookieHome.value !== undefined) {
+      backStackForHome.value = backCookieHome.value.split(",");
+    }
+    if (backCookieSearch.value !== undefined) {
+      backStackForSearch.value = backCookieSearch.value.split(",");
+    }
+    if (backCookieCommunity.value !== undefined) {
+      backStackForCommunity.value = backCookieCommunity.value.split(",");
+    }
+    if (backCookieMyPage.value !== undefined) {
+      backStackForMyPage.value = backCookieMyPage.value.split(",");
+    }
   }
 
   return {


### PR DESCRIPTION
### 도서 디테일의 버그를 수정했습니다.
- 관련 이슈는 #315 입니다.
- 등록된 리프가 조회되지 않는 버그가 있어 쿼리를 수정했습니다. 쿼리는 다음과 같습니다.
```
    @Override
    public Page<Leaf> getLeafCards(Long bookId, int page, int size) {

        QLeaf leaf = QLeaf.leaf;

        List<Leaf> leaves = queryFactory
                .selectFrom(leaf)
                .join(leaf.tree, tree).fetchJoin()
                .join(tree.member, member).fetchJoin()
                .join(tree.book, book).fetchJoin()
                .where(
                        leaf.tree.book.id.eq(bookId),
                        leaf.visibility.eq(true)
                )
                .orderBy(leaf.updateTime.desc())
                .offset((long) (page - 1) * size)
                .limit(size)
                .fetch();

        return new PageImpl<>(leaves, PageRequest.of(page, size), leaves.size());
    }
```

- 이 책의 나의 트리 카드의 UI가 깨진 것을 수정했습니다. HTML의 구조가 잘못되어 있었습니다.
- 도서 디테일의 카드들에 경로가 매핑되지 않던 것을 추가했습니다.
- 회고록의 내용이 HTML태그까지 보이던 것을 수정했습니다. 새로 추가된 `useDomParser` 컴포저블을 이용하면 html이 포함된 문자열에서 텍스트만 추출합니다.